### PR TITLE
Do not duplicate build of notice

### DIFF
--- a/lib/Honeybadger/Honeybadger.php
+++ b/lib/Honeybadger/Honeybadger.php
@@ -143,7 +143,7 @@ class Honeybadger {
 	public static function notify($exception, array $options = array())
 	{
 		$notice = self::build_notice_for($exception, $options);
-		return self::send_notice(self::build_notice_for($exception, $options));
+		return self::send_notice($notice);
 	}
 
 	/**


### PR DESCRIPTION
Unless I miss my guess, this is unnecessarily building twice because it is not using the local $notice var.
