### PR TITLE
Read api_key from environment variable.

### DIFF
--- a/lib/Honeybadger/Config.php
+++ b/lib/Honeybadger/Config.php
@@ -210,6 +210,9 @@ class Config extends SemiOpenStruct {
 		$this->notifier_version = Honeybadger::VERSION;
 		$this->notifier_url     = Honeybadger::NOTIFIER_URL;
 
+		// Read config from environment variables
+		$this->api_key = getenv('HONEYBADGER_API_KEY');
+
 		// Set user-specified configuration
 		$this->values($config);
 


### PR DESCRIPTION
I haven't tested this, but would be happy to; when I try to run the tests via `phpunit`, I get the following error:

```
PHP Warning:  require_once(/Users/josh/code/honeybadger-php/tests/../vendor/autoload.php): failed to open stream: No such file or directory in /Users/josh/code/honeybadger-php/tests/test_helper.php on line 3
```

It looks like I'm missing a vendor directory -- any ideas? Also, are you aware of how I could test this out in a local composer project before it has been published to packagist? (I'm looking for the equivalent of doing `gem 'honeybadger', path: '../honeybadger-ruby'` in a local Gemfile.)

Sorry for the n00b questions... It has been a while since I worked with PHP. :)