### PR TITLE
Alter references to assign maintenance/ownership to Honeybadger-io

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add honeybadger-php to your `composer.json`:
   // ...
   "require": {
     // ...
-    "gevans/honeybadger": "*"
+    "honeybadger-io/honeybadger": "*"
   }
   // ...
 }
@@ -47,7 +47,7 @@ Add honeybadger-php to your `composer.json`:
   // ...
   "require": {
     // ...
-    "gevans/honeybadger": "*"
+    "honeybadger-io/honeybadger": "*"
   }
   // ...
 }
@@ -74,12 +74,12 @@ $app->run();
 ## Additional Integrations
 
 This library will work well by following the
-[standalone installation](https://github.com/gevans/honeybadger-php#standalone-installation)
+[standalone installation](https://github.com/honeybadger-io/honeybadger-php#standalone-installation)
 steps outlined above. However, if you want to integrate your favorite framework,
 you can use the
-[Slim integration](https://github.com/gevans/honeybadger-php/blob/master/lib/Honeybadger/Slim.php)
+[Slim integration](https://github.com/honeybadger-io/honeybadger-php/blob/master/lib/Honeybadger/Slim.php)
 as a reference. If you've written your own integration that you'd like to share,
-send a [pull request](https://github.com/gevans/honeybadger-php/pull/new/master)
+send a [pull request](https://github.com/honeybadger-io/honeybadger-php/pull/new/master)
 adding it to the list:
 
 * *Nothing here yet...*
@@ -233,7 +233,7 @@ You can override any of those parameters.
 > or Rack environment (:cgi_data or :rack_env keys, respectively.)
 
 See `Honeybadger::Notice::__construct` in
-[lib/Honeybadger/Notice.php](https://github.com/gevans/honeybadger-php/blob/master/lib/Honeybadger/Notice.php)
+[lib/Honeybadger/Notice.php](https://github.com/honeybadger-io/honeybadger-php/blob/master/lib/Honeybadger/Notice.php)
 for more details.
 
 ## Filtering

--- a/composer.json
+++ b/composer.json
@@ -1,22 +1,28 @@
 {
-  "name": "gevans/honeybadger",
-  "description": "Unofficial PHP library for reporting errors to honeybadger.io",
+  "name": "honeybadger-io/honeybadger-php",
+  "description": "Official PHP library for reporting errors to honeybadger.io",
   "type": "library",
   "keywords": ["error", "reporting", "honeybadger", "exception"],
-  "homepage": "https://github.com/gevans/honeybadger-php",
+  "homepage": "https://github.com/honeybadger-io/honeybadger-php",
   "license": "MIT",
   "authors": [
+    {
+      "name": "Joshua Wood",
+      "email": "josh@honeybadger.io",
+      "homepage": "https://www.honeybadger.io/",
+      "role": "Maintainer"
+    },
     {
       "name": "Gabe Evans",
       "email": "gabe@ga.be",
       "homepage": "http://ga.be",
-      "role": "Maintainer"
+      "role": "Original Developer"
     }
   ],
   "support": {
-    "issues": "https://github.com/gevans/honeybadger-php/issues",
-    "wiki": "https://github.com/gevans/honeybadger-php/wiki",
-    "source": "https://github.com/gevans/honeybadger-php"
+    "issues": "https://github.com/honeybadger-io/honeybadger-php/issues",
+    "wiki": "https://github.com/honeybadger-io/honeybadger-php/wiki",
+    "source": "https://github.com/honeybadger-io/honeybadger-php"
   },
   "require": {
     "php": ">= 5.3.0",

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@ your applications, both with and without a framework.
 
 You can test the files within this directory by copying `config.sample.php` to
 `config.php` and updating the API key. Feel free to play with additional options
-which you'll find in [Honeybadger\Config](https://github.com/gevans/honeybadger-php/blob/master/lib/Honeybadger/Config.php).
+which you'll find in [Honeybadger\Config](https://github.com/honeybadger-io/honeybadger-php/blob/master/lib/Honeybadger/Config.php).
 
 ## Pow & rack-legacy
 


### PR DESCRIPTION
These changes alter the composer.json and other areas to align with honeybadger-io. This addresses the intent of #12.