### PR TITLE
Revert change to JSON formatting in Github - just plain ugly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ honeybadger-php is developed and tested against PHP versions 5.3, 5.4 and 5.5.
 
 Add honeybadger-php to your `composer.json`:
 
-```json
+```javascript
 {
   // ...
   "require": {
@@ -42,7 +42,7 @@ to Honeybadger. That's it!
 
 Add honeybadger-php to your `composer.json`:
 
-```json
+```javascript
 {
   // ...
   "require": {


### PR DESCRIPTION
I made this change thinking it was correct the other day, and after seeing the converted README I researched and determined that unless it is pure JSON (no comments), the javascript formatter looks better. 