### PR TITLE
Warrant and confirm that current PHP API works on PHP 5.3 and higher in 5.x series.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,9 @@ php:
   - 5.3
   - 5.4
   - 5.5
-
-matrix:
-  allow_failures:
-    - php: 5.5
+  - 5.6
 
 before_script:
   - COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev install
 
 script: phpunit
-
-notification:
-  email: "gabriel@codeconcoction.com"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "source": "https://github.com/honeybadger-io/honeybadger-php"
   },
   "require": {
-    "php": ">= 5.3.0",
+    "php": ">= 5.3.0, < 7.0",
     "guzzle/guzzle": ">= 3.0, < 3.5"
   },
   "require-dev": {


### PR DESCRIPTION
This declares that PHP 7.0 and above is not (yet) supported.