### PR TITLE
Guzzle upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   },
   "require": {
     "php": ">= 5.5.0, < 7.0",
-    "guzzle/guzzle": ">= 3.0, < 3.5",
+    "guzzlehttp/guzzle": ">= 6.0",
     "psr/log": "^1.0"
   },
   "require-dev": {

--- a/lib/Honeybadger/Honeybadger.php
+++ b/lib/Honeybadger/Honeybadger.php
@@ -79,7 +79,7 @@ class Honeybadger
         // Honeybadger is now initialized.
         self::$init = true;
 
-        self::$logger = new Logger\Void;
+        self::$logger = new Logger\Standard;
         self::$config = new Config;
         self::$sender = new Sender;
 

--- a/lib/Honeybadger/Logger/Standard.php
+++ b/lib/Honeybadger/Logger/Standard.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Honeybadger\Logger;
+
+use Honeybadger\Logger;
+
+/**
+ * Writes log entries to PHP error_log with the expectation that developers
+ * interested in this library's messages will implement their own logger or use
+ * a bundle/module already written for their framework or choice to replace
+ * this default in [Honeybadger::$logger].
+ *
+ * @package   Honeybadger
+ * @category  Logging
+ */
+class Standard extends Logger
+{
+    /**
+     * @param string      $severity
+     * @param string|null $message
+     *
+     * @return void
+     */
+    public function write($severity, $message = null)
+    {
+        error_log($severity . ': ' . $message);
+    }
+}

--- a/tests/Honeybadger/HoneybadgerTest.php
+++ b/tests/Honeybadger/HoneybadgerTest.php
@@ -33,7 +33,7 @@ class HoneybadgerTest extends TestCase
     {
         $this->restoreEnvironment();
         Honeybadger::init();
-        $this->assertTrue(Honeybadger::$logger instanceof Logger\Void);
+        $this->assertTrue(Honeybadger::$logger instanceof Logger\Standard);
     }
 
     public function test_configured()


### PR DESCRIPTION
This upgrades Guzzle to v6.2 (current) as well as adding in a default logger that logs to PHP error_log instead of the Logger\Void which would swallow API_KEY errors. 