### PR TITLE
Fix bug where $config is not initialized without calling `Honeybadger::init()` first

### DIFF
--- a/lib/Honeybadger/Config.php
+++ b/lib/Honeybadger/Config.php
@@ -472,3 +472,6 @@ class Config extends SemiOpenStruct
         $this->$option = null;
     }
 } // End Config
+
+// Additional measure to ensure defaults are initialized.
+Honeybadger::init();

--- a/lib/Honeybadger/Honeybadger.php
+++ b/lib/Honeybadger/Honeybadger.php
@@ -265,3 +265,6 @@ class Honeybadger
         return $result;
     }
 } // End Honeybadger
+
+// Additional measure to ensure defaults are initialized.
+Honeybadger::init();

--- a/tests/Honeybadger/HoneybadgerTest.php
+++ b/tests/Honeybadger/HoneybadgerTest.php
@@ -29,10 +29,9 @@ class HoneybadgerTest extends TestCase
         Honeybadger::resetContext();
     }
 
-    public function test_initialized_with_void_logger()
+    public function test_initialized_with_logger()
     {
         $this->restoreEnvironment();
-        Honeybadger::init();
         $this->assertTrue(Honeybadger::$logger instanceof Logger\Standard);
     }
 


### PR DESCRIPTION
This reverts 0b7b988dd4834a8c1b3f341e153c1a455bca0a67 and fixes the issue of the configuration instructions blowing up unless you explicitly call `Honeybadger::init()` beforehand. The implication is that FIG compliance is not 100% since there is a side-affect when initializing our library, but we can live with "relaxed compliance" imo.