### PR TITLE
Sending through proxy fails when proxy user and proxy pass are not set

### DIFF
--- a/lib/Honeybadger/Sender.php
+++ b/lib/Honeybadger/Sender.php
@@ -63,14 +63,17 @@ class Sender
         // $options['debug']    = true;
 
         if ($config->proxy_host) {
-            $options['proxy'] = 'tcp://' .
-                $config->proxy_user .
-                ':' .
-                $config->proxy_pass .
-                '@' .
-                $config->proxy_host .
-                ':' .
-                $config->proxy_port;
+            $options['proxy'] = 'tcp://';
+
+            if ($config->proxy_user) {
+                $options['proxy'] .= $config->proxy_user;
+                if ($config->proxy_pass) {
+                    $options['proxy'] .= ':' . $config->proxy_pass;
+                }
+                $options['proxy'] .= '@';
+            }
+
+            $options['proxy'] .= $config->proxy_host . ':' . $config->proxy_port;
         }
 
         if ($config->isSecure()) {


### PR DESCRIPTION
honeybadger-php tries to inject `proxy_user` and `proxy_pass` in proxy URL even when these are not set. The resulting proxy URL is polluted at its beginning with string `:@`, which breaks the call to curl (fails with a timeout).

Note: for reasons unknown, curl does accept string `:@` at the beginning of request URLs, but not at the beginning of proxy URLs.