### PR TITLE
Updated instructions for Laravel 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,35 @@ Honeybadger::$config->values(array(
 Your application will then report unhandled errors and exceptions
 to Honeybadger. That's it!
 
-#### Laravel Installation
+
+#### Laravel 5.x Installation
+
+Add Honeybadger to Laravel's exception handler in *app/exceptions/Handler.php*.  Before the Handler class is opened load Honeybadger:
+
+```php
+use Honeybadger\Honeybadger;
+
+Honeybadger::$config->values(array(
+    'api_key' => '[your-api-key]',
+));
+
+```
+
+And in the *report* function add the code that sends the exception to Honeybadger:
+
+```php
+public function report(Exception $exception)
+{
+    if ($this->shouldReport($exception)) {
+        Honeybadger::notify($exception);
+    }
+
+    parent::report($exception);
+}
+
+```
+
+#### Laravel 4.x Installation
 
 Report exceptions to Honeybadger from Laravel's exception handler in *app/start/global.php* (under the "Application Error Handler" heading):
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Your application will then report unhandled errors and exceptions
 to Honeybadger. That's it!
 
 
-#### Laravel 5.x Installation
+#### Laravel Installation
 
 Add Honeybadger to Laravel's exception handler in *app/exceptions/Handler.php*.  Before the Handler class is opened load Honeybadger:
 
@@ -73,26 +73,6 @@ public function report(Exception $exception)
 }
 
 ```
-
-#### Laravel 4.x Installation
-
-Report exceptions to Honeybadger from Laravel's exception handler in *app/start/global.php* (under the "Application Error Handler" heading):
-
-```php
-use Honeybadger\Honeybadger;
-
-Honeybadger::$config->values(array(
-    'api_key' => '[your-api-key]',
-));
-
-App::error(function(Exception $exception, $code)
-{
-    Honeybadger::notify($exception);
-    Log::error($exception);
-});
-```
-
-See [crywolf-laravel](https://github.com/honeybadger-io/crywolf-laravel) for an example Laravel application.
 
 #### Slim Installation
 


### PR DESCRIPTION
Should we just remove the Laravel 4 instructions?