### PR TITLE
Filter environment keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $app->run();
 
 ## Sample Application
 
-If you'd like to see the library in action before you integrate it with your apps, check out our [sample application](https://github.com/honeybadger-io/crywolf-laravel). 
+If you'd like to see the library in action before you integrate it with your apps, check out our [sample application](https://github.com/honeybadger-io/crywolf-laravel).
 
 You can deploy the sample app to your Heroku account by clicking this button:
 
@@ -117,8 +117,8 @@ Honeybadger::$config->values(array(
     'api_key'          => '[your-api-key]',
     'environment_name' => 'production',
 ));
-
 ```
+
 The following options are available to you:
 
 |  Name | Type | Description |
@@ -144,12 +144,13 @@ The following options are available to you:
 | source_extract_radius | `integer` | The radius around trace line to include in source excerpt. |
 | send_request_session | `boolean` | `true` to send session data, `false` to exclude. |
 | debug | `boolean` | `true` to log extra debug info, `false` to suppress. |
+| `ignore_http_keys` | `array` | `HTTP_*` keys to ignore when sending env data to Honeybadger. |
 
 ## Public Interface
 
 ### `Honeybadger::notify()`: Send an error to Honeybadger.
 
-If you've caught an exception in your code, but would still like to report the error to Honeybadger, this is the method for you. 
+If you've caught an exception in your code, but would still like to report the error to Honeybadger, this is the method for you.
 
 #### Examples:
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The following options are available to you:
 | source_extract_radius | `integer` | The radius around trace line to include in source excerpt. |
 | send_request_session | `boolean` | `true` to send session data, `false` to exclude. |
 | debug | `boolean` | `true` to log extra debug info, `false` to suppress. |
-| `ignore_http_keys` | `array` | `HTTP_*` keys to ignore when sending env data to Honeybadger. |
+| `filter_keys` | `array` | Filters the provided keys from then environment before sending it to Honeybadger. |
 
 ## Public Interface
 

--- a/lib/Honeybadger/Config.php
+++ b/lib/Honeybadger/Config.php
@@ -206,7 +206,7 @@ class Config extends SemiOpenStruct
         $this->notifier_version = Honeybadger::VERSION;
         $this->notifier_url     = Honeybadger::NOTIFIER_URL;
 
-        $this->filteredHttpEnviromentKeys = [];
+        $this->ignore_http_keys = [];
 
         // Read config from environment variables
         $this->api_key = getenv('HONEYBADGER_API_KEY');

--- a/lib/Honeybadger/Config.php
+++ b/lib/Honeybadger/Config.php
@@ -206,6 +206,8 @@ class Config extends SemiOpenStruct
         $this->notifier_version = Honeybadger::VERSION;
         $this->notifier_url     = Honeybadger::NOTIFIER_URL;
 
+        $this->filteredHttpEnviromentKeys = [];
+
         // Read config from environment variables
         $this->api_key = getenv('HONEYBADGER_API_KEY');
 

--- a/lib/Honeybadger/Config.php
+++ b/lib/Honeybadger/Config.php
@@ -206,7 +206,7 @@ class Config extends SemiOpenStruct
         $this->notifier_version = Honeybadger::VERSION;
         $this->notifier_url     = Honeybadger::NOTIFIER_URL;
 
-        $this->ignore_http_keys = [];
+        $this->filter_keys = [];
 
         // Read config from environment variables
         $this->api_key = getenv('HONEYBADGER_API_KEY');

--- a/lib/Honeybadger/Environment.php
+++ b/lib/Honeybadger/Environment.php
@@ -328,7 +328,7 @@ class Environment implements \ArrayAccess, \IteratorAggregate
         $env = Arr::overwrite($this->allowed_php_environment_keys, $_SERVER);
 
         foreach ($_SERVER as $key => $value) {
-            if (strpos($key, 'HTTP_') === 0) {
+            if ($this->isAllowedHttpKey($key)) {
                 $env[$key] = $value;
             }
         }
@@ -339,5 +339,11 @@ class Environment implements \ArrayAccess, \IteratorAggregate
         }
 
         return array_filter($env);
+    }
+
+    private function isAllowedHttpKey($key)
+    {
+      return strpos($key, 'HTTP_') === 0
+        && ! in_array($key, Honeybadger::$config->filteredHttpEnviromentKeys);
     }
 }

--- a/lib/Honeybadger/Environment.php
+++ b/lib/Honeybadger/Environment.php
@@ -328,10 +328,14 @@ class Environment implements \ArrayAccess, \IteratorAggregate
         $env = Arr::overwrite($this->allowed_php_environment_keys, $_SERVER);
 
         foreach ($_SERVER as $key => $value) {
-            if ($this->isAllowedHttpKey($key)) {
+            if ($this->isHttpKey($key)) {
                 $env[$key] = $value;
             }
         }
+
+        $env = array_filter($env, function ($key) {
+            return ! in_array($key, Honeybadger::$config->filter_keys);
+        }, ARRAY_FILTER_USE_KEY);
 
         if (!empty($_COOKIE)) {
             // Add cookies
@@ -341,9 +345,8 @@ class Environment implements \ArrayAccess, \IteratorAggregate
         return array_filter($env);
     }
 
-    private function isAllowedHttpKey($key)
+    private function isHttpKey($key)
     {
-      return strpos($key, 'HTTP_') === 0
-        && ! in_array($key, Honeybadger::$config->ignore_http_keys);
+      return strpos($key, 'HTTP_') === 0;
     }
 }

--- a/lib/Honeybadger/Environment.php
+++ b/lib/Honeybadger/Environment.php
@@ -344,6 +344,6 @@ class Environment implements \ArrayAccess, \IteratorAggregate
     private function isAllowedHttpKey($key)
     {
       return strpos($key, 'HTTP_') === 0
-        && ! in_array($key, Honeybadger::$config->filteredHttpEnviromentKeys);
+        && ! in_array($key, Honeybadger::$config->ignore_http_keys);
     }
 }

--- a/lib/Honeybadger/Environment.php
+++ b/lib/Honeybadger/Environment.php
@@ -319,34 +319,48 @@ class Environment implements \ArrayAccess, \IteratorAggregate
      *   variables](http://php.net/manual/en/reserved.variables.server.php) in
      *   `$_SERVER`.
      *
-     * * Allow variables prefixed with `HTTP_` (HTTP headers).
-     *
      * @return  array  The filtered PHP request environment.
      */
     private function sanitizedPhpEnvironment()
     {
-        $env = Arr::overwrite($this->allowed_php_environment_keys, $_SERVER);
-
-        foreach ($_SERVER as $key => $value) {
-            if ($this->isHttpKey($key)) {
-                $env[$key] = $value;
-            }
-        }
-
-        $env = array_filter($env, function ($key) {
-            return ! in_array($key, Honeybadger::$config->filter_keys);
-        }, ARRAY_FILTER_USE_KEY);
+        $env = array_merge(
+            $this->serverEnvironment(),
+            $this->httpEnvironment()
+        );
 
         if (!empty($_COOKIE)) {
             // Add cookies
             $env['rack.request.cookie_hash'] = $_COOKIE;
         }
 
-        return array_filter($env);
+        return array_filter($this->filteredEnvironment($env));
     }
 
-    private function isHttpKey($key)
+    /**
+     * @return array
+     */
+    private function serverEnvironment()
     {
-      return strpos($key, 'HTTP_') === 0;
+        return Arr::overwrite($this->allowed_php_environment_keys, $_SERVER);
+    }
+
+    /**
+     * @return array
+     */
+    private function httpEnvironment()
+    {
+        return array_filter($_SERVER, function ($key) {
+            return strpos($key, 'HTTP_') === 0;
+        }, ARRAY_FILTER_USE_KEY);
+    }
+
+    /**
+     * @return  array
+     */
+    private function filteredEnvironment($environment)
+    {
+        return array_filter($environment, function ($key) {
+            return ! in_array($key, Honeybadger::$config->filter_keys);
+        }, ARRAY_FILTER_USE_KEY);
     }
 }

--- a/tests/Honeybadger/ConfigTest.php
+++ b/tests/Honeybadger/ConfigTest.php
@@ -273,6 +273,6 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
 
     public function test_filtered_keys_is_set_by_default()
     {
-      $this->assertEquals([], (new Config())->filteredHttpEnviromentKeys);
+      $this->assertEquals([], (new Config())->ignore_http_keys);
     }
 }

--- a/tests/Honeybadger/ConfigTest.php
+++ b/tests/Honeybadger/ConfigTest.php
@@ -273,6 +273,6 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
 
     public function test_filtered_keys_is_set_by_default()
     {
-      $this->assertEquals([], (new Config())->ignore_http_keys);
+      $this->assertEquals([], (new Config())->filter_keys);
     }
 }

--- a/tests/Honeybadger/ConfigTest.php
+++ b/tests/Honeybadger/ConfigTest.php
@@ -270,4 +270,9 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $config = new Config(['debug' => false]);
         $this->assertEquals(Logger::DEBUG, $config->logLevel);
     }
+
+    public function test_filtered_keys_is_set_by_default()
+    {
+      $this->assertEquals([], (new Config())->filteredHttpEnviromentKeys);
+    }
 }

--- a/tests/Honeybadger/EnvironmentTest.php
+++ b/tests/Honeybadger/EnvironmentTest.php
@@ -363,7 +363,7 @@ class EnvironmentTest extends TestCase
 
     public function test_http_keys_can_be_filtered()
     {
-      Honeybadger::$config->filteredHttpEnviromentKeys = ['HTTP_SESSION_ID'];
+      Honeybadger::$config->ignore_http_keys = ['HTTP_SESSION_ID'];
 
       $_SERVER['HTTP_SESSION_ID'] = 'bar';
 

--- a/tests/Honeybadger/EnvironmentTest.php
+++ b/tests/Honeybadger/EnvironmentTest.php
@@ -360,4 +360,15 @@ class EnvironmentTest extends TestCase
 
         $this->assertNull($env->url);
     }
+
+    public function test_http_keys_can_be_filtered()
+    {
+      Honeybadger::$config->filteredHttpEnviromentKeys = ['HTTP_SESSION_ID'];
+
+      $_SERVER['HTTP_SESSION_ID'] = 'bar';
+
+      $env = Environment::factory();
+
+      $this->assertNull($env['HTTP_SESSION_ID']);
+    }
 }

--- a/tests/Honeybadger/EnvironmentTest.php
+++ b/tests/Honeybadger/EnvironmentTest.php
@@ -363,12 +363,14 @@ class EnvironmentTest extends TestCase
 
     public function test_http_keys_can_be_filtered()
     {
-      Honeybadger::$config->ignore_http_keys = ['HTTP_SESSION_ID'];
+      Honeybadger::$config->filter_keys = ['HTTP_SESSION_ID', 'PATH_INFO'];
 
       $_SERVER['HTTP_SESSION_ID'] = 'bar';
+      $_SERVER['PATH_INFO'] = 'bax';
 
       $env = Environment::factory();
 
       $this->assertNull($env['HTTP_SESSION_ID']);
+      $this->assertNull($env['PATH_INFO']);
     }
 }

--- a/tests/Honeybadger/EnvironmentTest.php
+++ b/tests/Honeybadger/EnvironmentTest.php
@@ -365,6 +365,7 @@ class EnvironmentTest extends TestCase
     {
       Honeybadger::$config->filter_keys = ['HTTP_SESSION_ID', 'PATH_INFO'];
 
+      $_SERVER['SERVER_NAME'] = 'CryWolfServer';
       $_SERVER['HTTP_SESSION_ID'] = 'bar';
       $_SERVER['PATH_INFO'] = 'bax';
 
@@ -372,5 +373,6 @@ class EnvironmentTest extends TestCase
 
       $this->assertNull($env['HTTP_SESSION_ID']);
       $this->assertNull($env['PATH_INFO']);
+      $this->assertEquals('CryWolfServer', $_SERVER['SERVER_NAME']);
     }
 }


### PR DESCRIPTION
Resolves #46 

## Adds
* Adds a new config key, `filter_keys `, to allow for ignore keys from the environment