### PR TITLE
Fixes issue with inconsistent reporting of URL port

### DIFF
--- a/lib/Honeybadger/Environment.php
+++ b/lib/Honeybadger/Environment.php
@@ -126,7 +126,13 @@ class Environment implements \ArrayAccess, \IteratorAggregate
      */
     public function host()
     {
-        return (empty($this['HTTP_HOST'])) ? $this['SERVER_NAME'] : $this['HTTP_HOST'];
+        if (!empty($this['HTTP_HOST'])) {
+            $host =  $this['HTTP_HOST'];
+        } else {
+            $host = $this['SERVER_NAME'];
+        }
+
+        return explode(':', $host)[0];
     }
 
     /**

--- a/tests/Honeybadger/EnvironmentTest.php
+++ b/tests/Honeybadger/EnvironmentTest.php
@@ -354,6 +354,22 @@ class EnvironmentTest extends TestCase
         $this->assertEquals('http://www.example.com:123/foo/bar/xyz?one=1&two=2&three=3', $env['url']);
     }
 
+    public function test_url_adds_port_when_also_in_host_key()
+    {
+        $env = Environment::factory(
+            [
+                'REQUEST_URI'  => '/foo/bar/xyz?one=1&two=2&three=3',
+                'SCRIPT_NAME'  => '/foo/index.php',
+                'HTTPS'        => '',
+                'HTTP_HOST'    => 'www.example.com:123',
+                'QUERY_STRING' => 'one=1&two=2&three=3',
+                'SERVER_PORT'  => '123',
+            ]
+        );
+
+        $this->assertEquals('http://www.example.com:123/foo/bar/xyz?one=1&two=2&three=3', $env['url']);
+    }
+
     public function test_url_returns_null_when_empty_host_and_path()
     {
         $env = Environment::factory([]);


### PR DESCRIPTION
Resolves #43

Fixes an issue where the port would be reported twice in the url if the
`$_SERVER['HTTP_HOST']` also included the port e.g.
`https://localhost:3030`. Added a step to remove the port when building
the URL using this key.