### PR TITLE
Allows for null api_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,17 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Allow `null` value for `api_key` config to improve local project development.
 
 ## [1.0.0] - 2018-07-07
-### Changes
+### Changed
 - Full library rewrite
 - PHP 7.1|7.2 requirement
 - See [README](README.md) for new installation, usage, and configuration details
 
 ## [0.4.1] - 2018-06-12
-## Fixes 
+## Fixed
 - PHP 5.5 support (#54)
 - Fixes port duplication in URL (#53)
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Default values are listed below.
 
 ```php
 [
-    // Honeybadger API Key (required)
+    // Honeybadger API Key
     'api_key' => null,
 
     'environment' => [

--- a/src/Config.php
+++ b/src/Config.php
@@ -2,7 +2,6 @@
 
 namespace Honeybadger;
 
-use InvalidArgumentException;
 use Honeybadger\Support\Repository;
 
 class Config extends Repository
@@ -13,7 +12,6 @@ class Config extends Repository
     public function __construct($config = [])
     {
         $this->items = $this->mergeConfig($config);
-        $this->validateRequiredKeys();
     }
 
     /**
@@ -50,17 +48,5 @@ class Config extends Repository
             ],
             'excluded_exceptions' => [],
         ], $config);
-    }
-
-    /**
-     * @return void
-     *
-     * @throws \InvalidArgument\Exception
-     */
-    private function validateRequiredKeys() : void
-    {
-        if (! isset($this->items['api_key']) || is_null($this->items['api_key'])) {
-            throw new InvalidArgumentException('$config[\'api_key\'] is required');
-        }
     }
 }

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -60,7 +60,7 @@ class Honeybadger implements Reporter
      */
     public function notify(Throwable $throwable, FoundationRequest $request = null) : array
     {
-        if ($this->excludedException($throwable)) {
+        if (! $this->shouldReport($throwable)) {
             return [];
         }
 
@@ -124,5 +124,14 @@ class Honeybadger implements Reporter
                 get_class($throwable),
                 $this->config['excluded_exceptions']
             );
+    }
+
+    /**
+     * @param  \Throwable  $throwable
+     * @return bool
+     */
+    private function shouldReport(Throwable $throwable) : bool
+    {
+        return ! $this->excludedException($throwable) && ! is_null($this->config['api_key']);
     }
 }

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -75,6 +75,10 @@ class Honeybadger implements Reporter
      */
     public function customNotification(array $payload) : array
     {
+        if (is_null($this->config['api_key'])) {
+            return [];
+        }
+
         $notification = (new CustomNotification($this->config, $this->context))
             ->make($payload);
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -4,19 +4,10 @@ namespace Honeybadger\Tests;
 
 use Honeybadger\Config;
 use Honeybadger\Honeybadger;
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class ConfigTest extends TestCase
 {
-    /** @test */
-    public function it_requires_the_api_key()
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        new Config;
-    }
-
     /** @test */
     public function it_merges_configuration_values()
     {

--- a/tests/HoneyBadgerTest.php
+++ b/tests/HoneyBadgerTest.php
@@ -400,4 +400,27 @@ class HoneyBadgerTest extends TestCase
 
         $this->assertEmpty($client->calls());
     }
+
+    /** @test */
+    public function custom_notifications_do_not_get_reported_when_config_key_is_null()
+    {
+        $client = HoneybadgerClient::new([
+             new Response(201),
+         ]);
+
+        $badger = Honeybadger::new([
+             'api_key' => null,
+             'handlers' => [
+                 'exception' => false,
+                 'error' => false,
+             ],
+         ], $client->make());
+
+        $response = $badger->customNotification([
+            'title' => 'Test Notification',
+            'message' => 'Test notification message',
+        ]);
+
+        $this->assertEmpty($client->calls());
+    }
 }

--- a/tests/HoneyBadgerTest.php
+++ b/tests/HoneyBadgerTest.php
@@ -380,4 +380,24 @@ class HoneyBadgerTest extends TestCase
             'id' => 'asdf123',
         ], $response);
     }
+
+    /** @test */
+    public function exceptions_do_not_get_reported_when_config_key_is_null()
+    {
+        $client = HoneybadgerClient::new([
+             new Response(201),
+         ]);
+
+        $badger = Honeybadger::new([
+             'api_key' => null,
+             'handlers' => [
+                 'exception' => false,
+                 'error' => false,
+             ],
+         ], $client->make());
+
+        $response = $badger->notify(new InvalidArgumentException('Test exception'));
+
+        $this->assertEmpty($client->calls());
+    }
 }


### PR DESCRIPTION
## Status
**READY**

## Description
Allow for a `null` config value for `api_key`. Most projects won't set this key for local development environments. When the config key is null, the reporters should do nothing.

## Related PRs
n/a


## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce
```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```
