### PR TITLE
Lower's http-foundation to fix compatibility with Laravel 5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Lowered http-foundation version requirements
 
 ## [1.1.0] - 2018-08-17
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.1|^7.2",
         "guzzlehttp/guzzle": "^6.3",
-        "symfony/http-foundation": "^4.0"
+        "symfony/http-foundation": ">=3.3|^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.10",


### PR DESCRIPTION
## Status
**READY**

## Description
Lowers the required version constraints for `symfony/http-foundation` so `honeybadger-laravel` can be compatible with Laravel 5.5 LTS.

## Related PRs
n/a

## Todos
- n/a Tests
- n/a Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce
I actually bootstrapped a wild setup locally with satis, `honeybadger-laravel` and Laravel 5.5, to test the install process.