### PR TITLE
Add raw notification method for fully customized payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+* Fully customizable notification method.
 
 ## [1.2.0] - 2018-09-13
 ### Changed

--- a/src/Contracts/Reporter.php
+++ b/src/Contracts/Reporter.php
@@ -25,6 +25,15 @@ interface Reporter
     public function customNotification(array $payload) : array;
 
     /**
+     * @param  callable  $callable
+     * @return array
+     *
+     * @throws \Honeybadger\Exceptions\ServiceException
+     * @throws \InvalidArgumentException
+     */
+    public function rawNotification(callable $callable) : array;
+
+    /**
      * @param  string  $key
      * @return void
      *

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -88,6 +88,30 @@ class Honeybadger implements Reporter
     /**
      * {@inheritdoc}
      */
+    public function rawNotification(callable $callable) : array
+    {
+        if (is_null($this->config['api_key'])) {
+            return [];
+        }
+
+        $notification = (new RawNotification($this->config, $this->context))
+            ->make($callable($this->config, $this->context));
+
+        return $this->client->notification($notification);
+    }
+
+    public function dynamicNotification(callable $closure)
+    {
+        if (is_null($this->config['api_key'])) {
+            return [];
+        }
+
+        return $this->client->notification($closure($this->config, $this->context));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function checkin(string $key) : void
     {
         $this->client->checkin($key);

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -100,15 +100,6 @@ class Honeybadger implements Reporter
         return $this->client->notification($notification);
     }
 
-    public function dynamicNotification(callable $closure)
-    {
-        if (is_null($this->config['api_key'])) {
-            return [];
-        }
-
-        return $this->client->notification($closure($this->config, $this->context));
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/HoneybadgerClient.php
+++ b/src/HoneybadgerClient.php
@@ -36,7 +36,7 @@ class HoneybadgerClient
      *
      * @throws \Honeybadger\Exceptions\ServiceException
      */
-    public function notification($notification) : array
+    public function notification(array $notification) : array
     {
         try {
             $response = $this->client->post(

--- a/src/RawNotification.php
+++ b/src/RawNotification.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Honeybadger;
+
+use InvalidArgumentException;
+use Honeybadger\Support\Repository;
+
+class RawNotification
+{
+    /**
+     * @var \Honeybadger\Config
+     */
+    protected $config;
+
+    /**
+     * @var \Honeybadger\Support\Repository
+     */
+    protected $context;
+
+    /**
+     * @param  \Honeybadger\Config  $config
+     * @param  \Honeybadger\Support\Repository  $context
+     */
+    public function __construct(Config $config, Repository $context)
+    {
+        $this->config = $config;
+        $this->context = $context;
+    }
+
+    /**
+     * @param  array  $payload
+     * @return array
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function make(array $payload) : array
+    {
+        $payload = array_merge(
+            [],
+            ['notifier' => $this->config['notifier']],
+            ['error' => []],
+            ['request' => ['context' => (object) $this->context->all()],
+            ],
+            ['server' => (object) []],
+            $payload
+        );
+
+        $this->validatePayload($payload);
+
+        return $payload;
+    }
+
+    /**
+     * @param  array  $payload
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function validatePayload(array $payload) : void
+    {
+        if (empty($payload['error']['class'])) {
+            throw new InvalidArgumentException('The notification error.class field is required');
+        }
+
+        if (empty($payload['notifier']['name'])) {
+            throw new InvalidArgumentException('The notification notifier.name field is required');
+        }
+    }
+}

--- a/tests/HoneyBadgerTest.php
+++ b/tests/HoneyBadgerTest.php
@@ -423,4 +423,110 @@ class HoneyBadgerTest extends TestCase
 
         $this->assertEmpty($client->calls());
     }
+
+    /** @test */
+    public function a_raw_notification_can_be_sent()
+    {
+        $client = HoneybadgerClient::new([
+            new Response(201),
+        ]);
+
+        $badger = Honeybadger::new([
+            'api_key' => 'asdf',
+            'handlers' => [
+                'exception' => false,
+                'error' => false,
+            ],
+        ], $client->make());
+
+        $badger->context('foo', 'bar');
+
+        $response = $badger->rawNotification(function ($config, $context) {
+            $this->assertEquals('asdf', $config['api_key']);
+            $this->assertEquals('bar', $context['foo']);
+
+            return [
+                'error' => [
+                    'class' => 'Special Error',
+                    'message' => 'Special Error: this was a super special case',
+                    'tags' => ['foo'],
+                ],
+                'request' => [
+                    'context' => ['baz' => 'qux'],
+                ],
+            ];
+        });
+
+        $request = $client->requestBody();
+
+        $this->assertArraySubset([
+            'error' => [
+                'class' => 'Special Error',
+                'message' => 'Special Error: this was a super special case',
+                'tags' => ['foo'],
+            ],
+            'request' => [
+                'context' => [
+                    'baz' => 'qux',
+                ],
+            ],
+        ], $request);
+
+        $this->assertArrayHasKey('notifier', $request);
+    }
+
+    /** @test */
+    public function raw_notification_notifier_name_field_is_required()
+    {
+        $client = HoneybadgerClient::new([
+            new Response(201),
+        ]);
+
+        $badger = Honeybadger::new([
+            'api_key' => 'asdf',
+            'handlers' => [
+                'exception' => false,
+                'error' => false,
+            ],
+        ], $client->make());
+
+        try {
+            $response = $badger->rawNotification(function ($config, $context) {
+                return [
+                    'notifier' => [],
+                    'error' => [
+                        'class' => 'Special Error',
+                    ],
+                ];
+            });
+        } catch (\InvalidArgumentException $e) {
+            $this->assertEquals('The notification notifier.name field is required', $e->getMessage());
+        }
+    }
+
+    /** @test */
+    public function raw_notification_error_class_field_is_required()
+    {
+        $client = HoneybadgerClient::new([
+            new Response(201),
+        ]);
+
+        $badger = Honeybadger::new([
+            'api_key' => 'asdf',
+            'handlers' => [
+                'exception' => false,
+                'error' => false,
+            ],
+        ], $client->make());
+
+        try {
+            $response = $badger->rawNotification(function ($config, $context) {
+                return [
+                    'error' => [],
+                ];
+            });
+        } catch (\InvalidArgumentException $e) {
+            $this->assertEquals('The notification error.class field is required', $e->getMessage());
+        }
+    }
 }


### PR DESCRIPTION
## Status
**READY**

## Description
This allows for a callable notification so fully customized notifications can be sent to the exception API.

There is base level validation for the few fields that are required for this to be sent.

## Related PRs
n/a

## Todos
- [x] Tests
- n/a Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce
```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```