### PR TITLE
Add php 73 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
 
 env:
   matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+* PHP 7.3 to the Travis build matrix
+
 ### Removed
 * php-cs-fixer dev dependency
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^7.1|^7.2",
+        "php": "^7.1",
         "guzzlehttp/guzzle": "^6.3",
         "symfony/http-foundation": ">=3.3 || ^4.1"
     },


### PR DESCRIPTION
## Status
**READY**

## Description
Adds PHP 7.3 to the Travis build matrix and removes unnecessary over specification of php versions in the composer manifest. 

## Related PRs
n/a

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Check CI process of PR
