### PR TITLE
Add monolog handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+* Fully customizable notification method.
 
 ## [1.3.0] 2018-12-17
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "require": {
         "php": "^7.1",
         "guzzlehttp/guzzle": "^6.3",
+        "monolog/monolog": "^1.24",
         "symfony/http-foundation": ">=3.3 || ^4.1"
     },
     "require-dev": {

--- a/src/Contracts/Reporter.php
+++ b/src/Contracts/Reporter.php
@@ -25,6 +25,15 @@ interface Reporter
     public function customNotification(array $payload) : array;
 
     /**
+     * @param  callable  $callable
+     * @return array
+     *
+     * @throws \Honeybadger\Exceptions\ServiceException
+     * @throws \InvalidArgumentException
+     */
+    public function rawNotification(callable $callable) : array;
+
+    /**
      * @param  string  $key
      * @return void
      *

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -88,6 +88,30 @@ class Honeybadger implements Reporter
     /**
      * {@inheritdoc}
      */
+    public function rawNotification(callable $callable) : array
+    {
+        if (is_null($this->config['api_key'])) {
+            return [];
+        }
+
+        $notification = (new RawNotification($this->config, $this->context))
+            ->make($callable($this->config, $this->context));
+
+        return $this->client->notification($notification);
+    }
+
+    public function dynamicNotification(callable $closure)
+    {
+        if (is_null($this->config['api_key'])) {
+            return [];
+        }
+
+        return $this->client->notification($closure($this->config, $this->context));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function checkin(string $key) : void
     {
         $this->client->checkin($key);

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -100,15 +100,6 @@ class Honeybadger implements Reporter
         return $this->client->notification($notification);
     }
 
-    public function dynamicNotification(callable $closure)
-    {
-        if (is_null($this->config['api_key'])) {
-            return [];
-        }
-
-        return $this->client->notification($closure($this->config, $this->context));
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/HoneybadgerClient.php
+++ b/src/HoneybadgerClient.php
@@ -36,7 +36,7 @@ class HoneybadgerClient
      *
      * @throws \Honeybadger\Exceptions\ServiceException
      */
-    public function notification($notification) : array
+    public function notification(array $notification) : array
     {
         try {
             $response = $this->client->post(

--- a/src/LogHandler.php
+++ b/src/LogHandler.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Honeybadger;
+
+use Monolog\Logger;
+use Honeybadger\Contracts\Reporter;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Handler\AbstractProcessingHandler;
+
+class LogHandler extends AbstractProcessingHandler
+{
+    /**
+     * @var \Honeybadger\Contracts\Reporter
+     */
+    protected $honeybadger;
+
+    /**
+     * @param  \Honeybadger\Contracts\Reporter  $honeybadger
+     * @param  int  $level
+     * @param  bool  $bubble
+     */
+    public function __construct(Reporter $honeybadger, int $level = Logger::DEBUG, bool $bubble = true)
+    {
+        parent::__construct($level, $bubble);
+
+        $this->honeybadger = $honeybadger;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function write(array $record)
+    {
+        $this->honeybadger->rawNotification(function ($config) use ($record) {
+            return [
+                'notifier' => array_merge($config['notifier'], ['name' => 'Honeybadger Log Handler']),
+                'error' => [
+                    'class' => $record['message'],
+                    'message' => $record['formatted'],
+                    'tags' => [
+                        'log',
+                        sprintf('%s.%s', $record['channel'], $record['level_name']),
+                    ],
+                    'fingerprint' => md5($record['formatted']),
+                ],
+                'request' => [
+                    'context' => [
+                        'context' => $record['context'],
+                        'level_name' => $record['level_name'],
+                        'log_channel' => $record['channel'],
+                        'message' => $record['message'],
+                    ],
+                ],
+            ];
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFormatter() : FormatterInterface
+    {
+        return new LineFormatter('[%datetime%] %channel%.%level_name%: %message%');
+    }
+}

--- a/src/RawNotification.php
+++ b/src/RawNotification.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Honeybadger;
+
+use InvalidArgumentException;
+use Honeybadger\Support\Repository;
+
+class RawNotification
+{
+    /**
+     * @var \Honeybadger\Config
+     */
+    protected $config;
+
+    /**
+     * @var \Honeybadger\Support\Repository
+     */
+    protected $context;
+
+    /**
+     * @param  \Honeybadger\Config  $config
+     * @param  \Honeybadger\Support\Repository  $context
+     */
+    public function __construct(Config $config, Repository $context)
+    {
+        $this->config = $config;
+        $this->context = $context;
+    }
+
+    /**
+     * @param  array  $payload
+     * @return array
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function make(array $payload) : array
+    {
+        $payload = array_merge(
+            [],
+            ['notifier' => $this->config['notifier']],
+            ['error' => []],
+            ['request' => ['context' => (object) $this->context->all()],
+            ],
+            ['server' => (object) []],
+            $payload
+        );
+
+        $this->validatePayload($payload);
+
+        return $payload;
+    }
+
+    /**
+     * @param  array  $payload
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function validatePayload(array $payload) : void
+    {
+        if (empty($payload['error']['class'])) {
+            throw new InvalidArgumentException('The notification error.class field is required');
+        }
+
+        if (empty($payload['notifier']['name'])) {
+            throw new InvalidArgumentException('The notification notifier.name field is required');
+        }
+    }
+}

--- a/tests/LogHandlerTest.php
+++ b/tests/LogHandlerTest.php
@@ -2,12 +2,12 @@
 
 namespace Honeybadger\Tests;
 
+use Monolog\Logger;
 use Honeybadger\LogHandler;
+use Honeybadger\Honeybadger;
 use PHPUnit\Framework\TestCase;
 use Honeybadger\Contracts\Reporter;
 use Monolog\Handler\AbstractProcessingHandler;
-use Monolog\Logger;
-use Honeybadger\Honeybadger;
 
 class LogHandlerTest extends TestCase
 {
@@ -17,7 +17,7 @@ class LogHandlerTest extends TestCase
         $reporter = $this->createMock(Reporter::class);
 
         $this->assertInstanceOf(
-            AbstractProcessingHandler::class, 
+            AbstractProcessingHandler::class,
             new LogHandler($reporter)
         );
     }
@@ -28,7 +28,8 @@ class LogHandlerTest extends TestCase
         $reporter = new class extends Honeybadger {
             public $notification;
 
-            public function __construct() {
+            public function __construct()
+            {
                 parent::__construct();
             }
 
@@ -44,7 +45,7 @@ class LogHandlerTest extends TestCase
         $logger->pushHandler(new LogHandler($reporter));
 
         $logger->info('Test log message');
-        
+
         $this->assertArraySubset([
             'notifier' => [
                 'name' => 'Honeybadger Log Handler',
@@ -64,16 +65,16 @@ class LogHandlerTest extends TestCase
                     'level_name' => 'INFO',
                     'log_channel' => 'test-logger',
                     'message' => 'Test log message',
-                ]
-            ]
+                ],
+            ],
           ], $reporter->notification);
 
         // [2019-01-20 14:56:20] test-logger.INFO: Test log message
         $this->assertRegExp(
-           '/\[[0-9-:\s]+\] test-logger\.INFO\: Test log message/', 
+           '/\[[0-9-:\s]+\] test-logger\.INFO\: Test log message/',
             $reporter->notification['error']['message']
         );
-        
+
         $this->assertFalse(empty($reporter->notification['error']['fingerprint']));
     }
 }

--- a/tests/LogHandlerTest.php
+++ b/tests/LogHandlerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Honeybadger\Tests;
+
+use Honeybadger\LogHandler;
+use PHPUnit\Framework\TestCase;
+use Honeybadger\Contracts\Reporter;
+use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Logger;
+use Honeybadger\Honeybadger;
+
+class LogHandlerTest extends TestCase
+{
+    /** @test */
+    public function it_can_be_created()
+    {
+        $reporter = $this->createMock(Reporter::class);
+
+        $this->assertInstanceOf(
+            AbstractProcessingHandler::class, 
+            new LogHandler($reporter)
+        );
+    }
+
+    /** @test */
+    public function it_will_format_a_log_for_honeybadger()
+    {
+        $reporter = new class extends Honeybadger {
+            public $notification;
+
+            public function __construct() {
+                parent::__construct();
+            }
+
+            public function rawNotification(callable $fn) : array
+            {
+                $this->notification = $fn($this->config);
+
+                return [];
+            }
+        };
+
+        $logger = new Logger('test-logger');
+        $logger->pushHandler(new LogHandler($reporter));
+
+        $logger->info('Test log message');
+        
+        $this->assertArraySubset([
+            'notifier' => [
+                'name' => 'Honeybadger Log Handler',
+                'url' => 'https://github.com/honeybadger-io/honeybadger-php',
+                'version' => Honeybadger::VERSION,
+            ],
+            'error' => [
+                'class' => 'Test log message',
+                'tags' => [
+                    'log',
+                    'test-logger.INFO',
+                ],
+            ],
+            'request' => [
+                'context' => [
+                    'context' => [],
+                    'level_name' => 'INFO',
+                    'log_channel' => 'test-logger',
+                    'message' => 'Test log message',
+                ]
+            ]
+          ], $reporter->notification);
+
+        // [2019-01-20 14:56:20] test-logger.INFO: Test log message
+        $this->assertRegExp(
+           '/\[[0-9-:\s]+\] test-logger\.INFO\: Test log message/', 
+            $reporter->notification['error']['message']
+        );
+        
+        $this->assertFalse(empty($reporter->notification['error']['fingerprint']));
+    }
+}


### PR DESCRIPTION
## Status
**WIP**

## Description
Adds a custom Monolog log handler that will send a custom formatted notification to Honeybadger. The custom payload content can be referenced in `tests/LogHandlerTest.php#it_will_format_a_log_for_honeybadger` test.

Resolves #13 

### Screenshot of log entry in HB
![46895057-c13e8c80-ce44-11e8-9135-7af31f2716c5](https://user-images.githubusercontent.com/5108034/51441145-7f6f7e80-1c9c-11e9-8344-71c7acc81872.png)

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce
```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```
