### PR TITLE
Accept grouping options for notification

### DIFF
--- a/src/Contracts/Reporter.php
+++ b/src/Contracts/Reporter.php
@@ -10,11 +10,12 @@ interface Reporter
     /**
      * @param  \Throwable  $throwable
      * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @param  array  $options
      * @return array
      *
      * @throws \Honeybadger\Exceptions\ServiceException
      */
-    public function notify(Throwable $throwable, FoundationRequest $request = null) : array;
+    public function notify(Throwable $throwable, FoundationRequest $request = null, array $options = []) : array;
 
     /**
      * @param  array  $payload

--- a/src/ExceptionNotification.php
+++ b/src/ExceptionNotification.php
@@ -51,13 +51,14 @@ class ExceptionNotification
     /**
      * @param  \Throwable  $e
      * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @param  array  $options
      * @return array
      */
-    public function make(Throwable $e, FoundationRequest $request = null) : array
+    public function make(Throwable $e, FoundationRequest $request = null, array $options = []) : array
     {
         $this->throwable = $e;
         $this->backtrace = $this->makeBacktrace();
-        $this->request = $this->makeRequest($request);
+        $this->request = $this->makeRequest($request, $options);
         $this->environment = $this->makeEnvironment();
 
         return $this->format();
@@ -82,6 +83,8 @@ class ExceptionNotification
                 'session' => $this->request->session(),
                 'url' => $this->request->url(),
                 'context' => $this->context->all(),
+                'component' => $this->request->component(),
+                'action' => $this->request->action(),
             ],
             'server' => [
                 'pid' => getmypid(),
@@ -113,11 +116,12 @@ class ExceptionNotification
 
     /**
      * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @param  array  $options
      * @return \Honeybadger\Request
      */
-    private function makeRequest(FoundationRequest $request = null) : Request
+    private function makeRequest(FoundationRequest $request = null, array $options = []) : Request
     {
-        return (new Request($request))
+        return (new Request($request, $options))
             ->filterKeys($this->config['request']['filter']);
     }
 }

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -58,14 +58,14 @@ class Honeybadger implements Reporter
     /**
      * {@inheritdoc}
      */
-    public function notify(Throwable $throwable, FoundationRequest $request = null) : array
+    public function notify(Throwable $throwable, FoundationRequest $request = null, array $options = []) : array
     {
         if (! $this->shouldReport($throwable)) {
             return [];
         }
 
         $notification = (new ExceptionNotification($this->config, $this->context))
-            ->make($throwable, $request);
+            ->make($throwable, $request, $options);
 
         return $this->client->notification($notification);
     }

--- a/src/Request.php
+++ b/src/Request.php
@@ -15,11 +15,18 @@ class Request
     protected $request;
 
     /**
-     * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @var array
      */
-    public function __construct(FoundationRequest $request = null)
+    protected $options;
+
+    /**
+     * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @param  array  $options
+     */
+    public function __construct(FoundationRequest $request = null, array $options = [])
     {
         $this->request = $request ?? FoundationRequest::createFromGlobals();
+        $this->options = $options;
 
         $this->keysToFilter = [
             'password',
@@ -64,6 +71,22 @@ class Request
     }
 
     /**
+     * @return string
+     */
+    public function component() : string
+    {
+        return $this->getOptionsByKey('component');
+    }
+
+    /**
+     * @return string
+     */
+    public function action() : string
+    {
+        return $this->getOptionsByKey('action');
+    }
+
+    /**
      * @return bool
      */
     private function httpRequest() : bool
@@ -85,5 +108,10 @@ class Request
         }
 
         return [];
+    }
+
+    private function getOptionsByKey($key) : string
+    {
+        return isset($this->options[$key]) ? $this->options[$key] : '';
     }
 }

--- a/tests/HoneyBadgerTest.php
+++ b/tests/HoneyBadgerTest.php
@@ -551,4 +551,31 @@ class HoneyBadgerTest extends TestCase
 
         $this->assertEmpty($badger->getContext()->all());
     }
+
+    /** @test */
+    public function it_can_send_grouping_options()
+    {
+        $client = HoneybadgerClient::new([
+            new Response(201),
+        ]);
+
+        $badger = Honeybadger::new([
+            'api_key' => 'asdf',
+            'handlers' => [
+                'exception' => false,
+                'error' => false,
+            ],
+        ], $client->make());
+
+        $options = [
+            'component' => 'sample',
+            'action' => 'index',
+        ];
+        $badger->notify(new Exception('Test exception'), null, $options);
+
+        $notification = $client->requestBody();
+
+        $this->assertEquals($options['component'], $notification['request']['component']);
+        $this->assertEquals($options['action'], $notification['request']['action']);
+    }
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -165,7 +165,6 @@ class RequestTest extends TestCase
         $session->invalidate();
     }
 
-
     /** @test */
     public function it_acccept_grouping_option_component()
     {
@@ -195,5 +194,4 @@ class RequestTest extends TestCase
             (new Request($request, $options))->action()
         );
     }
-
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -164,4 +164,36 @@ class RequestTest extends TestCase
 
         $session->invalidate();
     }
+
+
+    /** @test */
+    public function it_acccept_grouping_option_component()
+    {
+        $request = FoundationRequest::create(
+            'http://honeybadger.dev/test',
+            'GET'
+        );
+
+        $options = ['component' => 'test'];
+        $this->assertEquals(
+            $options['component'],
+            (new Request($request, $options))->component()
+        );
+    }
+
+    /** @test */
+    public function it_acccept_grouping_option_action()
+    {
+        $request = FoundationRequest::create(
+            'http://honeybadger.dev/test',
+            'GET'
+        );
+
+        $options = ['action' => 'index'];
+        $this->assertEquals(
+            $options['action'],
+            (new Request($request, $options))->action()
+        );
+    }
+
 }


### PR DESCRIPTION
## Status
**READY**

## Description
Partially resolves 74

In this PR just only making `component` and `action` acceptable among the notification options.
`fingerprint` is also grouping options but that is not a part of `request` but a part of `error` so not included in this change.

## Related PRs
na

## Todos
- [x] Tests
- [x] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```
