### PR TITLE
Handle empty API key

### DIFF
--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -75,7 +75,7 @@ class Honeybadger implements Reporter
      */
     public function customNotification(array $payload) : array
     {
-        if (is_null($this->config['api_key'])) {
+        if (empty($this->config['api_key'])) {
             return [];
         }
 
@@ -90,7 +90,7 @@ class Honeybadger implements Reporter
      */
     public function rawNotification(callable $callable) : array
     {
-        if (is_null($this->config['api_key'])) {
+        if (empty($this->config['api_key'])) {
             return [];
         }
 
@@ -167,6 +167,6 @@ class Honeybadger implements Reporter
      */
     private function shouldReport(Throwable $throwable) : bool
     {
-        return ! $this->excludedException($throwable) && ! is_null($this->config['api_key']);
+        return ! $this->excludedException($throwable) && ! empty($this->config['api_key']);
     }
 }

--- a/tests/HoneyBadgerTest.php
+++ b/tests/HoneyBadgerTest.php
@@ -382,14 +382,14 @@ class HoneyBadgerTest extends TestCase
     }
 
     /** @test */
-    public function exceptions_do_not_get_reported_when_config_key_is_null()
+    public function exceptions_do_not_get_reported_when_config_key_is_empty()
     {
         $client = HoneybadgerClient::new([
              new Response(201),
          ]);
 
         $badger = Honeybadger::new([
-             'api_key' => null,
+             'api_key' => '',
              'handlers' => [
                  'exception' => false,
                  'error' => false,
@@ -402,14 +402,14 @@ class HoneyBadgerTest extends TestCase
     }
 
     /** @test */
-    public function custom_notifications_do_not_get_reported_when_config_key_is_null()
+    public function custom_notifications_do_not_get_reported_when_config_key_is_empty()
     {
         $client = HoneybadgerClient::new([
              new Response(201),
          ]);
 
         $badger = Honeybadger::new([
-             'api_key' => null,
+             'api_key' => '',
              'handlers' => [
                  'exception' => false,
                  'error' => false,


### PR DESCRIPTION
## Status
**READY**

## Description
The existing approach would only prevent reporting if the configured API key was explicitly of type `null`. If the key was an empty string, the API call would be made, and fail.

It is common for API keys to be defined in a `.env` file, and also common for a values to be defined empty, especially in development environments when they are copied from a `.env.example` file and not being used for local development. When a value is left empty, it is parsed as an empty string rather than a null.

## Related PRs
None

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```