### PR TITLE
Add an option to not send data

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -47,6 +47,7 @@ class Config extends Repository
                 'proxy' => [],
             ],
             'excluded_exceptions' => [],
+            'report_data' => true,
         ], $config);
     }
 }

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -75,7 +75,7 @@ class Honeybadger implements Reporter
      */
     public function customNotification(array $payload) : array
     {
-        if (empty($this->config['api_key'])) {
+        if (empty($this->config['api_key']) || ! $this->config['report_data']) {
             return [];
         }
 
@@ -90,7 +90,7 @@ class Honeybadger implements Reporter
      */
     public function rawNotification(callable $callable) : array
     {
-        if (empty($this->config['api_key'])) {
+        if (empty($this->config['api_key']) || ! $this->config['report_data']) {
             return [];
         }
 
@@ -167,6 +167,8 @@ class Honeybadger implements Reporter
      */
     private function shouldReport(Throwable $throwable) : bool
     {
-        return ! $this->excludedException($throwable) && ! empty($this->config['api_key']);
+        return ! $this->excludedException($throwable)
+            && ! empty($this->config['api_key'])
+            && $this->config['report_data'];
     }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -40,6 +40,7 @@ class ConfigTest extends TestCase
                 'proxy' => [],
             ],
             'excluded_exceptions' => [],
+            'report_data' => true,
         ], $config);
     }
 }

--- a/tests/HoneyBadgerTest.php
+++ b/tests/HoneyBadgerTest.php
@@ -547,4 +547,34 @@ class HoneyBadgerTest extends TestCase
 
         $this->assertEmpty($badger->getContext()->all());
     }
+
+    /** @test */
+    public function no_data_is_sent_if_reporting_is_disabled()
+    {
+        $client = HoneybadgerClient::new([
+            new Response(201),
+        ]);
+
+        $badger = Honeybadger::new([
+            'api_key' => 'asdf',
+            'handlers' => [
+                'exception' => false,
+                'error' => false,
+            ],
+            'report_data' => false,
+        ], $client->make());
+
+        $badger->rawNotification(function ($config, $context) {
+            return [
+                'error' => [
+                    'class' => 'Foo',
+                ],
+            ];
+        });
+
+        $badger->customNotification([]);
+        $badger->notify(new \Exception('Whoops!'));
+
+        $this->assertEmpty($client->request());
+    }
 }

--- a/tests/HoneyBadgerTest.php
+++ b/tests/HoneyBadgerTest.php
@@ -171,7 +171,7 @@ class HoneyBadgerTest extends TestCase
             ],
         ], $client->make())->checkin('1234');
 
-        $request = $client->request();
+        $request = $client->request()[0]['request'];
 
         $this->assertEquals('check_in/1234', $request->getUri()->getPath());
     }

--- a/tests/LogHandlerTest.php
+++ b/tests/LogHandlerTest.php
@@ -72,7 +72,7 @@ class LogHandlerTest extends TestCase
 
         // [2019-01-20 14:56:20] test-logger.INFO: Test log message
         $this->assertRegExp(
-           '/\[[0-9-:\s]+\] test-logger\.INFO\: Test log message/',
+            '/\[[0-9-:\s]+\] test-logger\.INFO\: Test log message/',
             $reporter->notification['error']['message']
         );
 

--- a/tests/Mocks/HoneybadgerClient.php
+++ b/tests/Mocks/HoneybadgerClient.php
@@ -6,7 +6,7 @@ class HoneybadgerClient extends Client
 {
     public function request()
     {
-        return $this->calls() ?? $this->calls()[0]['request'];
+        return $this->calls();
     }
 
     public function requestBody()

--- a/tests/Mocks/HoneybadgerClient.php
+++ b/tests/Mocks/HoneybadgerClient.php
@@ -6,7 +6,7 @@ class HoneybadgerClient extends Client
 {
     public function request()
     {
-        return $this->calls()[0]['request'];
+        return $this->calls() ?? $this->calls()[0]['request'];
     }
 
     public function requestBody()


### PR DESCRIPTION
## Description
Adds an option for whether the library should send data back to the API, this is useful in testing or staging environments.

```php
new Honeybadger([
    'report_data' => false,
])
```