### PR TITLE
Update error handler with additional checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+* Error handler reporting supressed errors
 
 ## [1.5.0] 2019-05-30
 

--- a/src/Handlers/ErrorHandler.php
+++ b/src/Handlers/ErrorHandler.php
@@ -25,12 +25,16 @@ class ErrorHandler extends Handler implements HandlerContract
      * @param  string  $error
      * @param  string  $file
      * @param  int  $line
-     * @return void
+     * @return mixed
      *
      * @throws \Honeyhadger\Exceptions\ServiceException
      */
-    public function handle($code, $error, $file = null, $line = null) : void
+    public function handle($code, $error, $file = null, $line = null)
     {
+        if (error_reporting() === 0) {
+            return false;
+        }
+
         $this->honeybadger->notify(
             new ErrorException($error, $code, 0, $file, $line)
         );


### PR DESCRIPTION
## Description
Adds a check to ensure error reporting is enabled for that particular error. Fixes an issue where error suppression does not prevent the error from being reported.

## Related Issues
- https://github.com/honeybadger-io/honeybadger-laravel/issues/27


## Tasks
- [x] Tests
- [x] Changelog