### PR TITLE
Add method arguments to backtrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## Added
 - Added the ability to pass additional API parameters to exception captures specifically component and action ([#85](https://github.com/honeybadger-io/honeybadger-php/pull/85))
 - Adds fingerprint and tags to the additional paramaters ([#76](https://github.com/honeybadger-io/honeybadger-php/pull/76))
+- Adds method arguments to backtrace where possible ([#86](https://github.com/honeybadger-io/honeybadger-php/pull/86))
 
 ## [1.5.1] - 2019-06-10
 ### Fixed

--- a/src/BacktraceFactory.php
+++ b/src/BacktraceFactory.php
@@ -90,6 +90,7 @@ class BacktraceFactory
 
             return array_merge($context, [
                 'method' => $frame['function'] ?? null,
+                'args' => $frame['args'] ?? null,
             ]);
         }, $backtrace);
     }

--- a/tests/BacktraceFactoryTest.php
+++ b/tests/BacktraceFactoryTest.php
@@ -30,17 +30,18 @@ class BacktraceFactoryTest extends TestCase
     /** @test */
     public function it_correctly_formats_annonymous_functions()
     {
-        $throwTestException = function () {
+        $throwTestException = function ($foo) {
             throw new Exception('test');
         };
 
         try {
-            $throwTestException();
+            $throwTestException('bar');
         } catch (Throwable $e) {
             $backtrace = (new BacktraceFactory($e))->trace();
         }
 
         $this->assertEquals('Honeybadger\Tests\{closure}', $backtrace[0]['method']);
+        $this->assertEquals(['bar'], $backtrace[0]['args']);
     }
 
     /** @test */


### PR DESCRIPTION
## Description
Adds method arguments to backtrace where available. Resolves #84

The following code creates the following report in HB.


```php
<?php

function foo($foo, $bar)
{
    throw new \Exception('Test argument exception');
}

Route::get('/', function () {
    foo('asdfasdf', 'th293475239748at');
});
```
<img width="1154" alt="Screen Shot 2019-07-15 at 6 51 26 AM" src="https://user-images.githubusercontent.com/5108034/61211205-fd9d6280-a6cc-11e9-84d0-6a6d1475dabc.png">

## Todos
- [x] Tests
- [ ] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce
```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```
