### PR TITLE
Allow the component and action to also be set by the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-## Changed
+### Added
+- Methods to set the component and action ([#87](https://github.com/honeybadger-io/honeybadger-php/pull/87))
+
+### Changed
 - Backtrace args with objects now send only the class name ([#89](https://github.com/honeybadger-io/honeybadger-php/pull/89))
 
 ## [1.6.0] - 2019-07-18

--- a/src/ExceptionNotification.php
+++ b/src/ExceptionNotification.php
@@ -91,9 +91,9 @@ class ExceptionNotification
                 'params' => $this->request->params(),
                 'session' => $this->request->session(),
                 'url' => $this->request->url(),
-                'context' => $this->context->all(),
-                'component' => Arr::get($this->additionalParams, 'component', null) ?? Arr::get($this->context, 'component', null),
-                'action' => Arr::get($this->additionalParams, 'action', null) ?? Arr::get($this->context, 'action', null),
+                'context' => $this->context->except(['honeybadger_component', 'honeybadger_action']),
+                'component' => Arr::get($this->additionalParams, 'component', null) ?? Arr::get($this->context, 'honeybadger_component', null),
+                'action' => Arr::get($this->additionalParams, 'action', null) ?? Arr::get($this->context, 'honeybadger_action', null),
             ],
             'server' => [
                 'pid' => getmypid(),

--- a/src/ExceptionNotification.php
+++ b/src/ExceptionNotification.php
@@ -92,8 +92,8 @@ class ExceptionNotification
                 'session' => $this->request->session(),
                 'url' => $this->request->url(),
                 'context' => $this->context->all(),
-                'component' => Arr::get($this->additionalParams, 'component', null),
-                'action' => Arr::get($this->additionalParams, 'action', null),
+                'component' => Arr::get($this->additionalParams, 'component', null) ?? Arr::get($this->context, 'component', null),
+                'action' => Arr::get($this->additionalParams, 'action', null) ?? Arr::get($this->context, 'action', null),
             ],
             'server' => [
                 'pid' => getmypid(),

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -171,4 +171,26 @@ class Honeybadger implements Reporter
             && ! empty($this->config['api_key'])
             && $this->config['report_data'];
     }
+
+    /**
+     * @param string $component
+     * @return self
+     */
+    public function setComponent(string $component) : self
+    {
+        $this->context('honeybadger_component', $component);
+
+        return $this;
+    }
+
+    /**
+     * @param string $action
+     * @return self
+     */
+    public function setAction(string $action) : self
+    {
+        $this->context('honeybadger_action', $action);
+
+        return $this;
+    }
 }

--- a/src/Support/Repository.php
+++ b/src/Support/Repository.php
@@ -80,4 +80,27 @@ class Repository implements \ArrayAccess
     {
         unset($this->items[$offset]);
     }
+
+    /**
+     * Retuen all values except those passed.
+     *
+     * @param string|array $keys
+     * @return array
+     */
+    public function except($keys) : array
+    {
+        $items = $this->items;
+
+        if (is_array($keys)) {
+            foreach ($keys as $key) {
+                unset($items[$key]);
+            }
+
+            return $items;
+        }
+
+        unset($items[$keys]);
+
+        return $items;
+    }
 }

--- a/src/Support/Repository.php
+++ b/src/Support/Repository.php
@@ -82,7 +82,7 @@ class Repository implements \ArrayAccess
     }
 
     /**
-     * Retuen all values except those passed.
+     * Return all values except those specified.
      *
      * @param string|array $keys
      * @return array

--- a/tests/HoneyBadgerTest.php
+++ b/tests/HoneyBadgerTest.php
@@ -612,7 +612,7 @@ class HoneyBadgerTest extends TestCase
     }
 
     /** @test */
-    public function context_and_action_can_be_set_with_context()
+    public function context_and_action_can_be_set()
     {
         $client = HoneybadgerClient::new([
             new Response(201),

--- a/tests/HoneyBadgerTest.php
+++ b/tests/HoneyBadgerTest.php
@@ -203,14 +203,20 @@ class HoneyBadgerTest extends TestCase
             ],
         ]);
 
+        $errorHandler = set_error_handler(null);
+
+        $errorHandler = is_array($errorHandler)
+            ? $errorHandler[0]
+            : $errorHandler;
+
         $this->assertNotInstanceOf(
             ExceptionHandler::class,
-            set_exception_handler(null)[0]
+            $errorHandler
         );
 
         $this->assertNotInstanceOf(
             ErrorHandler::class,
-            set_error_handler(null)[0]
+            $errorHandler
         );
     }
 
@@ -620,8 +626,8 @@ class HoneyBadgerTest extends TestCase
             ],
         ], $client->make());
 
-        $badger->context('component', 'HomeController');
-        $badger->context('action', 'index');
+        $badger->setComponent('HomeController');
+        $badger->setAction('index');
 
         $badger->notify(new Exception('Test exception'));
 
@@ -629,5 +635,7 @@ class HoneyBadgerTest extends TestCase
 
         $this->assertEquals('HomeController', $notification['request']['component']);
         $this->assertEquals('index', $notification['request']['action']);
+        $this->assertArrayNotHasKey('component', $notification['request']['context']);
+        $this->assertArrayNotHasKey('action', $notification['request']['context']);
     }
 }

--- a/tests/HoneyBadgerTest.php
+++ b/tests/HoneyBadgerTest.php
@@ -604,4 +604,30 @@ class HoneyBadgerTest extends TestCase
         $this->assertEquals($options['fingerprint'], $notification['error']['fingerprint']);
         $this->assertEquals($options['tags'], $notification['error']['tags']);
     }
+
+    /** @test */
+    public function context_and_action_can_be_set_with_context()
+    {
+        $client = HoneybadgerClient::new([
+            new Response(201),
+        ]);
+
+        $badger = Honeybadger::new([
+            'api_key' => 'asdf',
+            'handlers' => [
+                'exception' => false,
+                'error' => false,
+            ],
+        ], $client->make());
+
+        $badger->context('component', 'HomeController');
+        $badger->context('action', 'index');
+
+        $badger->notify(new Exception('Test exception'));
+
+        $notification = $client->requestBody();
+
+        $this->assertEquals('HomeController', $notification['request']['component']);
+        $this->assertEquals('index', $notification['request']['action']);
+    }
 }

--- a/tests/RepositoryTest.php
+++ b/tests/RepositoryTest.php
@@ -53,4 +53,23 @@ class RepositoryTest extends TestCase
 
         $this->assertEquals(['foo' => 'bar'], $repository->all());
     }
+
+    /** @test */
+    public function it_will_exclude_multiple_keys()
+    {
+        $repository = new Repository(['foo' => 'bar', 'baz' => 'bar', 'qux' => 'bar']);
+        $items = $repository->except(['foo', 'baz']);
+
+        $this->assertArrayNotHasKey('foo', $items);
+        $this->assertArrayNotHasKey('baz', $items);
+    }
+
+    /** @test */
+    public function it_will_exclude_a_signel_key()
+    {
+        $repository = new Repository(['foo' => 'bar', 'baz' => 'bar', 'qux' => 'bar']);
+        $items = $repository->except('foo');
+
+        $this->assertArrayNotHasKey('foo', $items);
+    }
 }


### PR DESCRIPTION
## Description
By allowing the component and action to be set by the context as well as the additional parameters we can leverage it to easily set the component and action for the Laravel library.

```php
$badger = Honeybadger::new([
    'api_key' => 'asdf',
    'handlers' => [
        'exception' => false,
        'error' => false,
    ],
], $client->make());

$badger->setComponent('HomeController');
$badger->setAction('index');
```

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```