### PR TITLE
ErrorHandler: call `$this->previousHandler` only if it has callable value

### DIFF
--- a/src/Handlers/ErrorHandler.php
+++ b/src/Handlers/ErrorHandler.php
@@ -39,6 +39,8 @@ class ErrorHandler extends Handler implements HandlerContract
             new ErrorException($error, $code, 0, $file, $line)
         );
 
-        call_user_func($this->previousHandler, $code, $error, $file, $line);
+        if (is_callable($this->previousHandler)) {
+            call_user_func($this->previousHandler, $code, $error, $file, $line);
+        }
     }
 }


### PR DESCRIPTION
## Status
**READY**

## Description
Fix exception `call_user_func() expects parameter 1 to be a valid callback, no array or string given` when `set_error_handler()` returns `NULL`.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Just use the lib when user's handler is not set.