### PR TITLE
Change backtrace arguments to use class name rather than full object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## Changed
+- Backtrace args with objects now send only the class name ([#89](https://github.com/honeybadger-io/honeybadger-php/pull/89))
 
 ## [1.6.0] - 2019-07-18
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "symfony/http-foundation": ">=3.3 || ^4.1"
     },
     "require-dev": {
+        "larapack/dd": "^1.1",
         "mockery/mockery": "^1.1",
         "phpunit/phpunit": "^7.0|^8.0"
     },

--- a/src/BacktraceFactory.php
+++ b/src/BacktraceFactory.php
@@ -95,6 +95,12 @@ class BacktraceFactory
         }, $backtrace);
     }
 
+    /**
+     * Parse method arguments and make any transformations
+     *
+     * @param array $args
+     * @return array
+     */
     private function parseArgs(array $args) : array
     {
         return array_map(function ($arg) {

--- a/src/BacktraceFactory.php
+++ b/src/BacktraceFactory.php
@@ -90,9 +90,20 @@ class BacktraceFactory
 
             return array_merge($context, [
                 'method' => $frame['function'] ?? null,
-                'args' => $frame['args'] ?? null,
+                'args' => $this->parseArgs($frame['args']),
             ]);
         }, $backtrace);
+    }
+
+    private function parseArgs(array $args) : array
+    {
+        return array_map(function ($arg) {
+            if (is_object($arg)) {
+                return get_class($arg);
+            }
+
+            return $arg;
+        }, $args);
     }
 
     /**

--- a/src/BacktraceFactory.php
+++ b/src/BacktraceFactory.php
@@ -96,7 +96,7 @@ class BacktraceFactory
     }
 
     /**
-     * Parse method arguments and make any transformations
+     * Parse method arguments and make any transformations.
      *
      * @param array $args
      * @return array

--- a/tests/BacktraceFactoryTest.php
+++ b/tests/BacktraceFactoryTest.php
@@ -69,4 +69,31 @@ class BacktraceFactoryTest extends TestCase
             throw new RuntimeException('Exception Two', null, $e);
         }
     }
+
+    /** @test */
+    public function args_with_object_should_be_class_names()
+    {
+        $throwTestException = function ($foo, $bar) {
+            throw new Exception('test');
+        };
+
+        try {
+            $throwTestException('bar', new TestClass);
+        } catch (Throwable $e) {
+            $backtrace = (new BacktraceFactory($e))->trace();
+        }
+
+        $this->assertEquals('Honeybadger\Tests\{closure}', $backtrace[0]['method']);
+        $this->assertEquals(['bar', TestClass::class], $backtrace[0]['args']);
+    }
+}
+
+class TestClass
+{
+    protected $foo = 'bar';
+
+    public function __construct()
+    {
+        //
+    }
 }

--- a/tests/HoneyBadgerTest.php
+++ b/tests/HoneyBadgerTest.php
@@ -203,14 +203,20 @@ class HoneyBadgerTest extends TestCase
             ],
         ]);
 
+        $errorHandler = set_error_handler(null);
+
+        $errorHandler = is_array($errorHandler)
+            ? $errorHandler[0]
+            : $errorHandler;
+
         $this->assertNotInstanceOf(
             ExceptionHandler::class,
-            set_exception_handler(null)[0]
+            $errorHandler
         );
 
         $this->assertNotInstanceOf(
             ErrorHandler::class,
-            set_error_handler(null)[0]
+            $errorHandler
         );
     }
 


### PR DESCRIPTION
## Description
This PR fixes a potential issue with [v1.6.0](https://github.com/honeybadger-io/honeybadger-php/releases/tag/v1.6.0) where invalid JSON gets passed to Honeybadger's API. I can't re-create the issue but I have a theory that there is an issue converting some classes to JSON. The library now only passes the class name if a class is a parameter.

```php
Route::get('/', function (Request $request) {
    throwTestError('foo', $request);

    return view('welcome');
});

function throwTestError($something, $classThing)
{
    throw new \Exception('whoops');
}

```

<img width="1143" alt="Screen Shot 2019-08-08 at 9 58 26 AM" src="https://user-images.githubusercontent.com/5108034/62709340-2b6f8180-b9c3-11e9-86ee-220ec36098eb.png">
<img width="1145" alt="Screen Shot 2019-08-08 at 9 58 33 AM" src="https://user-images.githubusercontent.com/5108034/62709345-2e6a7200-b9c3-11e9-9fe9-79b89415026e.png">
