### PR TITLE
Update monolog support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Updated Monolog dependency to 2.0
 
 ## [1.7.0] - 2019-09-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Updated Monolog dependency to 2.0
+- Remove support for PHP 7.1
 
 ## [1.7.0] - 2019-09-04
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "guzzlehttp/guzzle": "^6.3",
         "monolog/monolog": "^2.0",
         "symfony/http-foundation": ">=3.3 || ^4.1"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.1",
         "guzzlehttp/guzzle": "^6.3",
-        "monolog/monolog": "^1.24",
+        "monolog/monolog": "^2.0",
         "symfony/http-foundation": ">=3.3 || ^4.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.1",
         "guzzlehttp/guzzle": "^6.3",
-        "monolog/monolog": "^2.0",
+        "monolog/monolog": "^1.41|^2.0",
         "symfony/http-foundation": ">=3.3 || ^4.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.1",
         "guzzlehttp/guzzle": "^6.3",
-        "monolog/monolog": "^1.41|^2.0",
+        "monolog/monolog": "^2.0",
         "symfony/http-foundation": ">=3.3 || ^4.1"
     },
     "require-dev": {

--- a/src/LogHandler.php
+++ b/src/LogHandler.php
@@ -30,7 +30,7 @@ class LogHandler extends AbstractProcessingHandler
     /**
      * {@inheritdoc}
      */
-    protected function write(array $record)
+    protected function write(array $record) : void
     {
         $this->honeybadger->rawNotification(function ($config) use ($record) {
             return [

--- a/tests/LogHandlerTest.php
+++ b/tests/LogHandlerTest.php
@@ -70,9 +70,9 @@ class LogHandlerTest extends TestCase
             ],
         ], array_only($reporter->notification['error'], ['class', 'tags']));
 
-        // [2019-01-20 14:56:20] test-logger.INFO: Test log message
+        // [2019-09-10T18:49:15.681206+00:00] test-logger.INFO: Test log message
         $this->assertRegExp(
-            '/\[[0-9-:\s]+\] test-logger\.INFO\: Test log message/',
+            '/\[[0-9-:+T.\s]+\] test-logger\.INFO\: Test log message/',
             $reporter->notification['error']['message']
         );
 


### PR DESCRIPTION
## Description
Updates monolog support for monolog@2.0. Fixes issues related to Laravel 6 (https://github.com/honeybadger-io/honeybadger-laravel/issues/38). Removes support for PHP 7.1


## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```
