### PR TITLE
Default args to an empty array

### DIFF
--- a/src/BacktraceFactory.php
+++ b/src/BacktraceFactory.php
@@ -90,7 +90,7 @@ class BacktraceFactory
 
             return array_merge($context, [
                 'method' => $frame['function'] ?? null,
-                'args' => $this->parseArgs($frame['args']),
+                'args' => $this->parseArgs($frame['args'] ?? []),
                 'class' => $frame['class'] ?? null,
                 'type' => $frame['type'] ?? null,
             ]);


### PR DESCRIPTION
## Description
Default backtrace args to an empty array if not defined.

Fixes #90 

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```

1.
