### PR TITLE
Use `JSON_PARTIAL_OUTPUT_ON_ERROR` when encoding JSON payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.0.0] - 2019-09-21
 ### Changed
+- Fixed an issue where a payload containing recursive data couldn't be posted to the backend ([#96](https://github.com/honeybadger-io/honeybadger-php/pull/96))
+
+## [2.0.0] - 2019-09-21
+### Changed
 - Updated Monolog dependency to 2.0
 - Remove support for PHP 7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-
-## [2.0.1] - 2019-09-21
-### Changed
+### Fixed
 - Fixed an issue where a payload containing recursive data couldn't be posted to the backend ([#96](https://github.com/honeybadger-io/honeybadger-php/pull/96))
 
 ## [2.0.0] - 2019-09-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [2.0.0] - 2019-09-21
+## [2.0.1] - 2019-09-21
 ### Changed
 - Fixed an issue where a payload containing recursive data couldn't be posted to the backend ([#96](https://github.com/honeybadger-io/honeybadger-php/pull/96))
 

--- a/src/HoneybadgerClient.php
+++ b/src/HoneybadgerClient.php
@@ -41,7 +41,7 @@ class HoneybadgerClient
         try {
             $response = $this->client->post(
                 'notices',
-                ['body' => json_encode($notification)]
+                ['body' => json_encode($notification, JSON_PARTIAL_OUTPUT_ON_ERROR)]
             );
         } catch (Exception $e) {
             throw ServiceException::generic();

--- a/tests/HoneybadgerClientTest.php
+++ b/tests/HoneybadgerClientTest.php
@@ -6,10 +6,10 @@ use Mockery;
 use Exception;
 use GuzzleHttp\Client;
 use Honeybadger\Config;
-use Honeybadger\Honeybadger;
 use PHPUnit\Framework\TestCase;
 use Honeybadger\HoneybadgerClient;
 use Honeybadger\Exceptions\ServiceException;
+use Symfony\Component\HttpFoundation\Response;
 
 class HoneybadgerClientTest extends TestCase
 {
@@ -39,5 +39,36 @@ class HoneybadgerClientTest extends TestCase
 
         $client = new HoneybadgerClient($config, $mock);
         $client->checkin('1234');
+    }
+
+    /** @test */
+    public function doesnt_throw_when_passing_recursive_data()
+    {
+        $data = [];
+        $data['data'] = &$data;
+
+        $config = new Config(['api_key' => '1234']);
+
+        $responseMock = Mockery::mock(Response::class)
+            ->shouldReceive([
+                'getStatusCode' => Response::HTTP_CREATED,
+                'getBody' => '',
+            ])
+            ->getMock();
+
+        $clientMock = Mockery::mock(Client::class);
+        $clientMock->shouldReceive('post')
+            ->with('notices', ['body' => '{"data":null}'])
+            ->andReturn($responseMock);
+
+        $client = new HoneybadgerClient($config, $clientMock);
+
+        $assertionMessage = 'Unexpected result when passing recursive payload to `notification`';
+        try {
+            $result = $client->notification($data);
+            $this->assertEquals([], $result, $assertionMessage);
+        } catch (ServiceException $e) {
+            $this->assertTrue(false, $assertionMessage);
+        }
     }
 }


### PR DESCRIPTION
This proposes a fix for https://github.com/honeybadger-io/honeybadger-php/issues/93,
where a recursive payload made the notification to fail because `json_encode`
returns `null` in that case.

## Status

**READY** (imho)

## Description

As stated in #93 , we have a problem with some exceptions that contain recursive references in their trance. Those cannot be `json_encoded` successfully, so `json_encode` silently returns `null`. Thus this exception won't be reported to the honeybadger backend.

## Todos

- [x] Tests
- [ ] Documentation
- [x] Changelog Entry (unreleased)

(I don't know 

## Steps to Test or Reproduce

I provided a test case in `tests/HoneybadgerClientTest.php` that covers that behaviour. Running that test without the fix fails. 

```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```

