### PR TITLE
Added a callable check for the exception handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - Fixed an issue where a payload containing recursive data couldn't be posted to the backend ([#96](https://github.com/honeybadger-io/honeybadger-php/pull/96))
+- - Fixed an issue where the previous exception handler is not callable but called ([#97](https://github.com/honeybadger-io/honeybadger-php/pull/97))
 
 ## [2.0.0] - 2019-09-21
 ### Changed

--- a/src/Handlers/ExceptionHandler.php
+++ b/src/Handlers/ExceptionHandler.php
@@ -30,6 +30,8 @@ class ExceptionHandler extends Handler implements HandlerContract
     {
         $this->honeybadger->notify($e);
 
-        call_user_func($this->previousHandler, $e);
+        if (is_callable($this->previousHandler)) {
+            call_user_func($this->previousHandler, $e);
+        }
     }
 }


### PR DESCRIPTION
## Description
Added a check to make sure the previous global exception handler is callable before we call it.

## Todos
- [x] Tests
- [ ] Documentation
- [x] Changelog Entry (unreleased)
