### PR TITLE
Backports JSON_PARTIAL_OUTPUT_ON_ERROR fixes to 1.x

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -9,7 +9,7 @@ $rules = [
     'not_operator_with_successor_space' => true,
     'no_useless_else' => true,
     'ordered_imports' => [
-        'sortAlgorithm' => 'length',
+        'sortAlgorithm' => 'alpha',
     ],
     'single_quote' => true,
     'ternary_operator_spaces' => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## [1.7.2] - 2019-11-22
 ### Fixed
 - Fixed an issue where the previous exception handler is not callable but called ([#97](https://github.com/honeybadger-io/honeybadger-php/pull/97))
-
+- Fixed an issue where a payload containing recursive data couldn't be posted to the backend ([#96](https://github.com/honeybadger-io/honeybadger-php/pull/96))
+-
 ## [1.7.1] - 2019-09-13
 ### Fixed
 - Default args for backtrace functions ([#92](https://github.com/honeybadger-io/honeybadger-php/pull/92))

--- a/src/HoneybadgerClient.php
+++ b/src/HoneybadgerClient.php
@@ -41,7 +41,7 @@ class HoneybadgerClient
         try {
             $response = $this->client->post(
                 'notices',
-                ['body' => json_encode($notification)]
+                ['body' => json_encode($notification, JSON_PARTIAL_OUTPUT_ON_ERROR)]
             );
         } catch (Exception $e) {
             throw ServiceException::generic();

--- a/tests/HoneybadgerClientTest.php
+++ b/tests/HoneybadgerClientTest.php
@@ -2,13 +2,13 @@
 
 namespace Honeybadger\Tests;
 
-use Mockery;
 use Exception;
 use GuzzleHttp\Client;
 use Honeybadger\Config;
-use PHPUnit\Framework\TestCase;
-use Honeybadger\HoneybadgerClient;
 use Honeybadger\Exceptions\ServiceException;
+use Honeybadger\HoneybadgerClient;
+use Mockery;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Response;
 
 class HoneybadgerClientTest extends TestCase


### PR DESCRIPTION
Backports JSON_PARTIAL_OUTPUT_ON_ERROR fixes to 1.x