### PR TITLE
Updates docbloc reference for context to allow array

### DIFF
--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -110,7 +110,7 @@ class Honeybadger implements Reporter
 
     /**
      * @param  int|string  $key
-     * @param  int|string  $value
+     * @param  int|string|array  $value
      * @return void
      */
     public function context($key, $value) : void


### PR DESCRIPTION
## Description
Updates doc block for `context()` to allow for `array`. I wouldn't recommend sending objects through as it may have unintended side effects.

Resolves #102 