### PR TITLE
Fix error handler exception mapping

### DIFF
--- a/src/Handlers/ErrorHandler.php
+++ b/src/Handlers/ErrorHandler.php
@@ -36,7 +36,7 @@ class ErrorHandler extends Handler implements HandlerContract
         }
 
         $this->honeybadger->notify(
-            new ErrorException($error, $code, 0, $file, $line)
+            new ErrorException($error, 0, $code, $file, $line)
         );
 
         if (is_callable($this->previousHandler)) {

--- a/src/Handlers/ErrorHandler.php
+++ b/src/Handlers/ErrorHandler.php
@@ -15,7 +15,7 @@ class ErrorHandler extends Handler implements HandlerContract
     /**
      * @return void
      */
-    public function register() : void
+    public function register(): void
     {
         $this->previousHandler = set_error_handler([$this, 'handle']);
     }


### PR DESCRIPTION
## Description
The order of arguments for mapping the error handler to an
ErrorException were inverted for argument 2 and 3.

Reference https://www.php.net/manual/en/class.errorexception.php