### PR TITLE
Add environment to custom and raw notifications

### DIFF
--- a/src/CustomNotification.php
+++ b/src/CustomNotification.php
@@ -44,7 +44,9 @@ class CustomNotification
             ['request' => [
                 'context' => (object) $this->context->all(), ],
             ],
-            ['server' => (object) []]
+            ['server' => (object) [
+              'environment_name' => $this->config['environment_name'],
+            ]]
         );
     }
 }

--- a/src/CustomNotification.php
+++ b/src/CustomNotification.php
@@ -45,7 +45,7 @@ class CustomNotification
                 'context' => (object) $this->context->all(), ],
             ],
             ['server' => (object) [
-              'environment_name' => $this->config['environment_name'],
+                'environment_name' => $this->config['environment_name'],
             ]]
         );
     }

--- a/src/RawNotification.php
+++ b/src/RawNotification.php
@@ -41,7 +41,9 @@ class RawNotification
             ['error' => []],
             ['request' => ['context' => (object) $this->context->all()],
             ],
-            ['server' => (object) []],
+            ['server' => (object) [
+              'environment_name' => $this->config['environment_name'],
+            ]],
             $payload
         );
 

--- a/src/RawNotification.php
+++ b/src/RawNotification.php
@@ -42,7 +42,7 @@ class RawNotification
             ['request' => ['context' => (object) $this->context->all()],
             ],
             ['server' => (object) [
-              'environment_name' => $this->config['environment_name'],
+                'environment_name' => $this->config['environment_name'],
             ]],
             $payload
         );


### PR DESCRIPTION
## Description
While integrating this into drupal using https://github.com/nathandentzau/drupal-honeybadger and using a custom notification, I noticed that the environment name did not populate in the Honeybadger dashboard.

This PR will add the environment name to custom and raw notifications. It defaults to production because of https://github.com/honeybadger-io/honeybadger-php/blob/master/src/Config.php#L40 .

## Related PRs
None


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```

1.
