### PR TITLE
Adds backtrace frame context

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "php": "^7.2",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "monolog/monolog": "^2.0",
+        "spatie/regex": "^1.4",
         "symfony/http-foundation": ">=3.3 || ^4.1"
     },
     "require-dev": {

--- a/src/BacktraceFactory.php
+++ b/src/BacktraceFactory.php
@@ -61,7 +61,7 @@ class BacktraceFactory
             $previousCauses[] = [
                 'class' => get_class($e),
                 'message' => $e->getMessage(),
-                'backtrace' => (new self($e))->trace(),
+                'backtrace' => (new self($e, $this->config))->trace(),
             ];
 
             return $this->formatPrevious($e, $previousCauses);

--- a/src/BacktraceFactory.php
+++ b/src/BacktraceFactory.php
@@ -172,10 +172,7 @@ class BacktraceFactory
 
     private function fileFromApplication(string $filePath, array $vendorPaths): bool
     {
-        $path = $this->config['project_root'] 
-            ? Regex::replace('/'.preg_quote($this->config['project_root'].'/', '/').'/', '', $filePath)->result()
-            : '';
-
+        $path = $this->appendProjectRootToFilePath($filePath);
 
         if (Regex::match('/'.array_shift($vendorPaths).'/', $path)->hasMatch()) {
             return false;
@@ -186,5 +183,14 @@ class BacktraceFactory
         }
 
         return true;
+    }
+
+    private function appendProjectRootToFilePath(string $filePath): string
+    {
+        $pregProjectRoot = preg_quote($this->config['project_root'].'/', '/');
+
+        return $this->config['project_root'] 
+            ? Regex::replace('/'.$pregProjectRoot.'/', '', $filePath)->result()
+            : '';
     }
 }

--- a/src/BacktraceFactory.php
+++ b/src/BacktraceFactory.php
@@ -166,7 +166,7 @@ class BacktraceFactory
             'file' => $frame['file'],
             'number' => (string) $frame['line'],
             'context' => $this->fileFromApplication($frame['file'], $this->config['vendor_paths'])
-                ? 'app' : 'vendor', 
+                ? 'app' : 'all', 
         ];
     }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -20,34 +20,37 @@ class Config extends Repository
      */
     private function mergeConfig($config = []): array
     {
-        return array_merge([
-            'api_key' => null,
-            'notifier' => [
-                'name' => 'Honeybadger PHP',
-                'url' => 'https://github.com/honeybadger-io/honeybadger-php',
-                'version' => Honeybadger::VERSION,
-            ],
-            'environment' => [
-                'filter' => [],
-                'include' => [],
-            ],
-            'request' => [
-                'filter' => [],
-            ],
-            'version' => '',
-            'hostname' => gethostname(),
-            'project_root' => '',
-            'environment_name' => 'production',
-            'handlers' => [
-                'exception' => true,
-                'error' => true,
-            ],
-            'client' => [
-                'timeout' => 0,
-                'proxy' => [],
-            ],
-            'excluded_exceptions' => [],
-            'report_data' => true,
-        ], $config);
+    return array_merge([
+        'api_key' => null,
+        'notifier' => [
+            'name' => 'Honeybadger PHP',
+            'url' => 'https://github.com/honeybadger-io/honeybadger-php',
+            'version' => Honeybadger::VERSION,
+        ],
+        'environment' => [
+            'filter' => [],
+            'include' => [],
+        ],
+        'request' => [
+            'filter' => [],
+        ],
+        'version' => '',
+        'hostname' => gethostname(),
+        'project_root' => '',
+        'environment_name' => 'production',
+        'handlers' => [
+            'exception' => true,
+            'error' => true,
+        ],
+        'client' => [
+            'timeout' => 0,
+            'proxy' => [],
+        ],
+        'excluded_exceptions' => [],
+        'report_data' => true,
+        'vendor_paths' => [
+            'vendor\/.*',
+        ],
+    ], $config);
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -20,37 +20,37 @@ class Config extends Repository
      */
     private function mergeConfig($config = []): array
     {
-    return array_merge([
-        'api_key' => null,
-        'notifier' => [
-            'name' => 'Honeybadger PHP',
-            'url' => 'https://github.com/honeybadger-io/honeybadger-php',
-            'version' => Honeybadger::VERSION,
-        ],
-        'environment' => [
-            'filter' => [],
-            'include' => [],
-        ],
-        'request' => [
-            'filter' => [],
-        ],
-        'version' => '',
-        'hostname' => gethostname(),
-        'project_root' => '',
-        'environment_name' => 'production',
-        'handlers' => [
-            'exception' => true,
-            'error' => true,
-        ],
-        'client' => [
-            'timeout' => 0,
-            'proxy' => [],
-        ],
-        'excluded_exceptions' => [],
-        'report_data' => true,
-        'vendor_paths' => [
-            'vendor\/.*',
-        ],
-    ], $config);
+        return array_merge([
+            'api_key' => null,
+            'notifier' => [
+                'name' => 'Honeybadger PHP',
+                'url' => 'https://github.com/honeybadger-io/honeybadger-php',
+                'version' => Honeybadger::VERSION,
+            ],
+            'environment' => [
+                'filter' => [],
+                'include' => [],
+            ],
+            'request' => [
+                'filter' => [],
+            ],
+            'version' => '',
+            'hostname' => gethostname(),
+            'project_root' => '',
+            'environment_name' => 'production',
+            'handlers' => [
+                'exception' => true,
+                'error' => true,
+            ],
+            'client' => [
+                'timeout' => 0,
+                'proxy' => [],
+            ],
+            'excluded_exceptions' => [],
+            'report_data' => true,
+            'vendor_paths' => [
+                'vendor\/.*',
+            ],
+        ], $config);
     }
 }

--- a/src/ExceptionNotification.php
+++ b/src/ExceptionNotification.php
@@ -120,7 +120,7 @@ class ExceptionNotification
      */
     private function makeBacktrace(): BacktraceFactory
     {
-        return new BacktraceFactory($this->throwable);
+        return new BacktraceFactory($this->throwable, $this->config);
     }
 
     /**

--- a/tests/BacktraceFactoryTest.php
+++ b/tests/BacktraceFactoryTest.php
@@ -123,7 +123,7 @@ class BacktraceFactoryTest extends TestCase
             $backtrace = (new BacktraceFactory($e, $config))->trace();
         }
 
-        $this->assertEquals('vendor', $backtrace[0]['context']);
+        $this->assertEquals('all', $backtrace[0]['context']);
     }
 
     protected static function throwStaticException()

--- a/tests/BacktraceFactoryTest.php
+++ b/tests/BacktraceFactoryTest.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Throwable;
+use Honeybadger\Config;
 
 class BacktraceFactoryTest extends TestCase
 {
@@ -17,7 +18,7 @@ class BacktraceFactoryTest extends TestCase
         try {
             $this->throwNestedExceptions();
         } catch (Throwable $e) {
-            $backtrace = (new BacktraceFactory($e))->trace()[0];
+            $backtrace = (new BacktraceFactory($e, new Config))->trace()[0];
         }
 
         $this->assertEquals('throwNestedExceptions', $backtrace['method']);
@@ -36,7 +37,7 @@ class BacktraceFactoryTest extends TestCase
         try {
             $throwTestException('bar');
         } catch (Throwable $e) {
-            $backtrace = (new BacktraceFactory($e))->trace();
+            $backtrace = (new BacktraceFactory($e, new Config))->trace();
         }
 
         $this->assertEquals('Honeybadger\Tests\{closure}', $backtrace[0]['method']);
@@ -54,7 +55,7 @@ class BacktraceFactoryTest extends TestCase
         try {
             throwTestException();
         } catch (Throwable $e) {
-            $backtrace = (new BacktraceFactory($e))->trace();
+            $backtrace = (new BacktraceFactory($e, new Config))->trace();
         }
 
         $this->assertEquals('Honeybadger\Tests\throwTestException', $backtrace[0]['method']);
@@ -66,7 +67,7 @@ class BacktraceFactoryTest extends TestCase
         try {
             throw new Exception('test');
         } catch (Throwable $e) {
-            $backtrace = (new BacktraceFactory($e))->trace();
+            $backtrace = (new BacktraceFactory($e, new Config))->trace();
         }
 
         $this->assertEquals(self::class, $backtrace[0]['class']);
@@ -78,7 +79,7 @@ class BacktraceFactoryTest extends TestCase
         try {
             throw new Exception('test');
         } catch (Throwable $e) {
-            $backtrace = (new BacktraceFactory($e))->trace();
+            $backtrace = (new BacktraceFactory($e, new Config))->trace();
         }
 
         $this->assertEquals('->', $backtrace[0]['type']);
@@ -90,10 +91,39 @@ class BacktraceFactoryTest extends TestCase
         try {
             self::throwStaticException();
         } catch (Throwable $e) {
-            $backtrace = (new BacktraceFactory($e))->trace();
+            $backtrace = (new BacktraceFactory($e, new Config))->trace();
         }
 
         $this->assertEquals('::', $backtrace[0]['type']);
+    }
+
+    /** @test */
+    public function context_is_sent_for_frames()
+    {
+        try {
+            throw new Exception('test');
+        } catch (Throwable $e) {
+            $backtrace = (new BacktraceFactory($e, new Config))->trace();
+        }
+
+        $this->assertEquals('app', $backtrace[0]['context']);
+    }
+
+    /** @test */
+    public function context_is_sent_as_vendor()
+    {
+        $config = new Config([
+            'project_root' => dirname(getcwd().'/..'),
+            'vendor_paths' => ['tests\/.*'],
+        ]);
+
+        try {
+            throw new Exception('test');
+        } catch (Throwable $e) {
+            $backtrace = (new BacktraceFactory($e, $config))->trace();
+        }
+
+        $this->assertEquals('vendor', $backtrace[0]['context']);
     }
 
     protected static function throwStaticException()
@@ -120,7 +150,7 @@ class BacktraceFactoryTest extends TestCase
         try {
             $throwTestException('bar', new TestClass);
         } catch (Throwable $e) {
-            $backtrace = (new BacktraceFactory($e))->trace();
+            $backtrace = (new BacktraceFactory($e, new Config))->trace();
         }
 
         $this->assertEquals('Honeybadger\Tests\{closure}', $backtrace[0]['method']);

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -41,6 +41,9 @@ class ConfigTest extends TestCase
             ],
             'excluded_exceptions' => [],
             'report_data' => true,
+            'vendor_paths' => [
+                'vendor',
+            ],
         ], $config);
     }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -42,7 +42,7 @@ class ConfigTest extends TestCase
             'excluded_exceptions' => [],
             'report_data' => true,
             'vendor_paths' => [
-                'vendor',
+                'vendor\/.*',
             ],
         ], $config);
     }


### PR DESCRIPTION
## Description
Adds backtrace frame context for app/vendor.

Reference: https://github.com/honeybadger-io/honeybadger-laravel/issues/9

We'll implement the feature here and then add port the stock configuration to [honeybadger-laravel](https://github.com/honeybadger-io/honeybadger-laravel).

**Notes**
- `vendor_paths` is relative to `project_root`
