### PR TITLE
Pass verify option to guzzle config

### DIFF
--- a/src/HoneybadgerClient.php
+++ b/src/HoneybadgerClient.php
@@ -90,6 +90,7 @@ class HoneybadgerClient
             ],
             'timeout' => $this->config['client']['timeout'],
             'proxy' => $this->config['client']['proxy'],
+            'verify' => $this->config['client']['verify'],
         ]);
     }
 }


### PR DESCRIPTION
I was having issues with the guzzle "verify" client option. By default HoneybaderClient sets "verify" to true. Sometimes this is NOT the best option because some developers do NOT have access to the php.ini or openssl configuration. https://docs.guzzlephp.org/en/stable/request-options.html#verify

I commented on #112 (https://github.com/honeybadger-io/honeybadger-php/issues/112#issuecomment-777080461) and @joshuap provided that another issue #121 may be related.

Took a little time and found that in Laravel the client configuration is not brought in generally, instead is specified with specific context as seen in lines 91-92.

I've added the "verify" option that works from Laravel's honeybader configuration. Easy test is to set "verify" to false.

## Status
**READY/WIP/HOLD**

## Description
A few sentences describing the overall goals of the pull request's commits.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```

1.
