### PR TITLE
add null check and default value for verify option

### DIFF
--- a/src/HoneybadgerClient.php
+++ b/src/HoneybadgerClient.php
@@ -90,7 +90,7 @@ class HoneybadgerClient
             ],
             'timeout' => $this->config['client']['timeout'],
             'proxy' => $this->config['client']['proxy'],
-            'verify' => $this->config['client']['verify'],
+            'verify' => $this->config['client']['verify'] ?? true,
         ]);
     }
 }


### PR DESCRIPTION
The latest update breaks laravel installations unless you modify the `config/honeybadger.php` (if you have published it to your config directory), the latest update assumes that the verify option exists in the config, this is not the case if you are upgrading from `honeybadger-laravel 3.4` (or older), so we need a null check here.