### PR TITLE
Correctly match vendor_paths on Windows

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,6 +2,7 @@ name: Run Tests
 
 on: 
   push:
+  pull_request:
   schedule:
     - cron: "0 0 * * *"
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 coverage
 docs
 vendor
+.phpunit.result.cache

--- a/src/BacktraceFactory.php
+++ b/src/BacktraceFactory.php
@@ -173,6 +173,9 @@ class BacktraceFactory
     {
         $path = $this->appendProjectRootToFilePath($filePath);
 
+        // On Windows, file paths use backslashes, so we have to normalise them
+        $path = str_replace('\\', '/', $path);
+
         if (Regex::match('/'.array_shift($vendorPaths).'/', $path)->hasMatch()) {
             return false;
         }


### PR DESCRIPTION
On Windows, file paths use backslashes (`\`) as opposed to Unix forward slashes (`/`). This makes matching of vendor_paths to not work correctly.