### PR TITLE
Add support for ServiceException handlers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         }
     ],
     "require": {
+        "ext-json": "*",
         "php": "^7.2|^8.0",
         "guzzlehttp/guzzle": "^6.3|^7.0.1",
         "monolog/monolog": "^2.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Honeybadger Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Honeybadger Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
 </phpunit>

--- a/src/Config.php
+++ b/src/Config.php
@@ -3,6 +3,7 @@
 namespace Honeybadger;
 
 use Honeybadger\Support\Repository;
+use Honeybadger\Exceptions\ServiceException;
 
 class Config extends Repository
 {
@@ -15,7 +16,8 @@ class Config extends Repository
     }
 
     /**
-     * @param  array  $config
+     * @param array $config
+     *
      * @return array
      */
     private function mergeConfig($config = []): array
@@ -27,6 +29,9 @@ class Config extends Repository
                 'url' => 'https://github.com/honeybadger-io/honeybadger-php',
                 'version' => Honeybadger::VERSION,
             ],
+            'service_exception_handler' => function (ServiceException $e) {
+                throw $e;
+            },
             'environment' => [
                 'filter' => [],
                 'include' => [],

--- a/src/Config.php
+++ b/src/Config.php
@@ -2,8 +2,8 @@
 
 namespace Honeybadger;
 
-use Honeybadger\Support\Repository;
 use Honeybadger\Exceptions\ServiceException;
+use Honeybadger\Support\Repository;
 
 class Config extends Repository
 {

--- a/src/Exceptions/ServiceExceptionFactory.php
+++ b/src/Exceptions/ServiceExceptionFactory.php
@@ -21,34 +21,29 @@ class ServiceExceptionFactory
         $this->response = $response;
     }
 
-    public function make(): Exception
+    public function make(): ServiceException
     {
         return $this->exception();
     }
 
-    /**
-     * @return void
-     *
-     * @throws \Honeybadger\Exceptions\ServiceException
-     */
-    private function exception(): void
+    private function exception(): ServiceException
     {
         if ($this->response->getStatusCode() === Response::HTTP_FORBIDDEN) {
-            throw ServiceException::invalidApiKey();
+            return ServiceException::invalidApiKey();
         }
 
         if ($this->response->getStatusCode() === Response::HTTP_UNPROCESSABLE_ENTITY) {
-            throw ServiceException::invalidPayload();
+            return ServiceException::invalidPayload();
         }
 
         if ($this->response->getStatusCode() === Response::HTTP_TOO_MANY_REQUESTS) {
-            throw ServiceException::rateLimit();
+            return ServiceException::rateLimit();
         }
 
         if ($this->response->getStatusCode() === Response::HTTP_INTERNAL_SERVER_ERROR) {
-            throw ServiceException::serverError();
+            return ServiceException::serverError();
         }
 
-        throw ServiceException::generic();
+        return ServiceException::generic();
     }
 }

--- a/src/HoneybadgerClient.php
+++ b/src/HoneybadgerClient.php
@@ -2,11 +2,11 @@
 
 namespace Honeybadger;
 
-use Throwable;
 use GuzzleHttp\Client;
 use Honeybadger\Exceptions\ServiceException;
 use Honeybadger\Exceptions\ServiceExceptionFactory;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 class HoneybadgerClient
 {
@@ -43,11 +43,13 @@ class HoneybadgerClient
             );
         } catch (Throwable $e) {
             $this->handleServiceException(ServiceException::generic());
+
             return [];
         }
 
         if ($response->getStatusCode() !== Response::HTTP_CREATED) {
             $this->handleServiceException((new ServiceExceptionFactory($response))->make());
+
             return [];
         }
 
@@ -66,11 +68,13 @@ class HoneybadgerClient
             $response = $this->client->head(sprintf('check_in/%s', $key));
         } catch (Throwable $e) {
             $this->handleServiceException(ServiceException::generic());
+
             return;
         }
 
         if ($response->getStatusCode() !== Response::HTTP_OK) {
             $this->handleServiceException((new ServiceExceptionFactory($response))->make());
+
             return;
         }
     }

--- a/src/HoneybadgerClient.php
+++ b/src/HoneybadgerClient.php
@@ -2,7 +2,7 @@
 
 namespace Honeybadger;
 
-use Exception;
+use Throwable;
 use GuzzleHttp\Client;
 use Honeybadger\Exceptions\ServiceException;
 use Honeybadger\Exceptions\ServiceExceptionFactory;
@@ -22,7 +22,7 @@ class HoneybadgerClient
 
     /**
      * @param  \Honeybadger\Config  $config
-     * @param  \GuzzleHttp\Client  $client
+     * @param  \GuzzleHttp\Client|null  $client
      */
     public function __construct(Config $config, Client $client = null)
     {
@@ -33,8 +33,6 @@ class HoneybadgerClient
     /**
      * @param  array  $notification
      * @return array
-     *
-     * @throws \Honeybadger\Exceptions\ServiceException
      */
     public function notification(array $notification): array
     {
@@ -43,12 +41,14 @@ class HoneybadgerClient
                 'notices',
                 ['body' => json_encode($notification, JSON_PARTIAL_OUTPUT_ON_ERROR)]
             );
-        } catch (Exception $e) {
-            throw ServiceException::generic();
+        } catch (Throwable $e) {
+            $this->handleServiceException(ServiceException::generic());
+            return [];
         }
 
         if ($response->getStatusCode() !== Response::HTTP_CREATED) {
-            throw (new ServiceExceptionFactory($response))->make();
+            $this->handleServiceException((new ServiceExceptionFactory($response))->make());
+            return [];
         }
 
         return (string) $response->getBody()
@@ -59,20 +59,26 @@ class HoneybadgerClient
     /**
      * @param  string  $key
      * @return void
-     *
-     * @throws \Honeybadger\Exceptions\ServiceException
      */
     public function checkin(string $key): void
     {
         try {
             $response = $this->client->head(sprintf('check_in/%s', $key));
-        } catch (Exception $e) {
-            throw ServiceException::generic();
+        } catch (Throwable $e) {
+            $this->handleServiceException(ServiceException::generic());
+            return;
         }
 
         if ($response->getStatusCode() !== Response::HTTP_OK) {
-            throw (new ServiceExceptionFactory($response))->make();
+            $this->handleServiceException((new ServiceExceptionFactory($response))->make());
+            return;
         }
+    }
+
+    private function handleServiceException(ServiceException $e): void
+    {
+        $serviceExceptionHandler = $this->config['service_exception_handler'];
+        call_user_func_array($serviceExceptionHandler, [$e]);
     }
 
     /**

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -13,6 +13,9 @@ class ConfigTest extends TestCase
     {
         $config = (new Config(['api_key' => '1234']))->all();
 
+        $this->assertArrayHasKey('service_exception_handler', $config);
+        unset($config['service_exception_handler']);
+
         $this->assertEquals([
             'api_key' => '1234',
             'notifier' => [

--- a/tests/HoneybadgerClientTest.php
+++ b/tests/HoneybadgerClientTest.php
@@ -43,6 +43,26 @@ class HoneybadgerClientTest extends TestCase
     }
 
     /** @test */
+    public function allows_service_exceptions_to_be_handled()
+    {
+        $message= null;
+        $config = new Config([
+            'api_key' => '1234',
+            'service_exception_handler' => function (ServiceException $e) use (&$message) {
+                $message = $e->getMessage();
+            },
+        ]);
+        $mock = Mockery::mock(Client::class)->makePartial();
+        $mock->shouldReceive('post')->andThrow(new Exception);
+
+        $client = new HoneybadgerClient($config, $mock);
+        $client->notification([]);
+
+        $this->assertEquals("There was an error sending the payload to Honeybadger.", $message);
+    }
+
+
+    /** @test */
     public function doesnt_throw_when_passing_recursive_data()
     {
         $data = [];

--- a/tests/HoneybadgerClientTest.php
+++ b/tests/HoneybadgerClientTest.php
@@ -61,7 +61,6 @@ class HoneybadgerClientTest extends TestCase
         $this->assertEquals('There was an error sending the payload to Honeybadger.', $message);
     }
 
-
     /** @test */
     public function doesnt_throw_when_passing_recursive_data()
     {

--- a/tests/HoneybadgerClientTest.php
+++ b/tests/HoneybadgerClientTest.php
@@ -45,7 +45,7 @@ class HoneybadgerClientTest extends TestCase
     /** @test */
     public function allows_service_exceptions_to_be_handled()
     {
-        $message= null;
+        $message = null;
         $config = new Config([
             'api_key' => '1234',
             'service_exception_handler' => function (ServiceException $e) use (&$message) {
@@ -58,7 +58,7 @@ class HoneybadgerClientTest extends TestCase
         $client = new HoneybadgerClient($config, $mock);
         $client->notification([]);
 
-        $this->assertEquals("There was an error sending the payload to Honeybadger.", $message);
+        $this->assertEquals('There was an error sending the payload to Honeybadger.', $message);
     }
 
 

--- a/tests/ServiceExceptionTest.php
+++ b/tests/ServiceExceptionTest.php
@@ -51,7 +51,7 @@ class ServiceExceptionTest extends TestCase
     }
 
     /** @test */
-    public function it_throws_an_generic_exception_if_all_else_fails()
+    public function it_throws_a_generic_exception_if_all_else_fails()
     {
         $this->expectExceptionObject(ServiceException::generic());
 


### PR DESCRIPTION
## Status
**READY**

## Description
Allow the user to specify what the library should do when it encounters an error while sending data to Honeybadger. For instance:

```php
$honeybadger = Honeybadger\Honeybadger::new([
    'api_key' => 'abc123',
    'service_exception_handler' => function (ServiceException $e) {
        $logger->warning($e);
    },
]);
```

For framework integrations (Laravel and Lumen), the user won't have to worry about this; we'll automatically set the handler to log the exception.

Note: the current default behaviour is to throw, so we need to either change it or prominently mention the behaviour in our docs.

Fixes #121.

## Related PRs
Laravel - https://github.com/honeybadger-io/honeybadger-laravel/pull/70
Docs - https://github.com/honeybadger-io/docs/pull/90