### PR TITLE
Branch alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## [2.4.0] - 2021-02-15
+### Added
+- Added config for Guzzle SSL verification ([#124](https://github.com/honeybadger-io/honeybadger-php/pull/124)) ([#123](https://github.com/honeybadger-io/honeybadger-php/pull/123))
+
 ## [2.3.0] - 2020-11-29
 ### Changed
 - Added PHP8 Support ([#118](https://github.com/honeybadger-io/honeybadger-php/pull/118))

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,11 @@
         "mockery/mockery": "^1.4",
         "phpunit/phpunit": "^8.5|^9.4"
     },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.x-dev"
+        }
+    },
     "autoload": {
         "psr-4": {
             "Honeybadger\\": "src"

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -19,7 +19,7 @@ class Honeybadger implements Reporter
     /**
      * SDK Version.
      */
-    const VERSION = '2.3.0';
+    const VERSION = '2.4.0';
 
     /**
      * Honeybadger API URL.


### PR DESCRIPTION
Adding a branch alias will make it easier to contribute to the project, with the branch alias you only have to add a custom repository in your local composer.json as below and run `composer update`.

```
{
    "type": "path",
    "url": "~/github/honeybadger-php"
}
```

This is especially helpful when like me you are actually using `honeybadger-laravel` in your project, without the branch-alias you need to manually import `honeybadger-php` with an inline alias to be able to use your local version instead of the version  required by `honeybadger-laravel`, the branch alias makes it much quicker to work on a local copy instead.

Hope this makes sence.

TLDR: developer experience goes up. 🚀