### PR TITLE
Limit backtrace args size (Fixes #122)

### DIFF
--- a/src/ArgumentValueNormalizer.php
+++ b/src/ArgumentValueNormalizer.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Honeybadger;
+
+/**
+ * The ArgumentValueNormalizer "normalizes" backtrace args for improved serialisation:
+ * - To limit size, the number of keys included in an array is limited.
+ * - Additionally, the nesting level is limited. Higher levels of nesting will return "..." for non-primitives.
+ * - Arrays and objects are serialised properly at each level.
+ *
+ * The normalized values can then be JSON encoded as usual.
+ */
+class ArgumentValueNormalizer
+{
+    protected const MAX_KEYS_IN_ARRAY = 50;
+    protected const MAX_DEPTH = 10;
+
+    public static function normalize($value, int $currentDepth = 0)
+    {
+        switch (gettype($value)) {
+            case 'array':
+                if ($currentDepth > static::MAX_DEPTH) {
+                    $n = count($value);
+                    $items = $n > 1 ? 'items' : 'item';
+                    return "Array($n $items)";
+                }
+
+                return static::normalizeArray($value, $currentDepth);
+
+            case 'object':
+                return static::normalizeObject($value);
+
+            default:
+                return $value;
+        }
+    }
+
+    protected static function normalizeArray(array $array, int $currentDepth = 0): array
+    {
+        $normalized = [];
+        $keyCount = 0;
+        foreach ($array as $key => $item) {
+            $keyCount++;
+            if ($keyCount > static::MAX_KEYS_IN_ARRAY) {
+                break;
+            }
+            $normalized[$key] = static::normalize($item, $currentDepth + 1);
+        }
+        return $normalized;
+    }
+
+    /**
+     * Currently, objects are normalized to the class name. This isn't ideal (see GH issue 133),
+     * but we can change it at any time.
+     */
+    protected static function normalizeObject(object $object)
+    {
+        return get_class($object);
+    }
+}

--- a/src/ArgumentValueNormalizer.php
+++ b/src/ArgumentValueNormalizer.php
@@ -22,6 +22,7 @@ class ArgumentValueNormalizer
                 if ($currentDepth > static::MAX_DEPTH) {
                     $n = count($value);
                     $items = $n > 1 ? 'items' : 'item';
+
                     return "Array($n $items)";
                 }
 
@@ -46,6 +47,7 @@ class ArgumentValueNormalizer
             }
             $normalized[$key] = static::normalize($item, $currentDepth + 1);
         }
+
         return $normalized;
     }
 

--- a/src/BacktraceFactory.php
+++ b/src/BacktraceFactory.php
@@ -114,11 +114,7 @@ class BacktraceFactory
     private function parseArgs(array $args): array
     {
         return array_map(function ($arg) {
-            if (is_object($arg)) {
-                return get_class($arg);
-            }
-
-            return $arg;
+            return ArgumentValueNormalizer::normalize($arg);
         }, $args);
     }
 

--- a/tests/ArgumentValueNormalizerTest.php
+++ b/tests/ArgumentValueNormalizerTest.php
@@ -41,7 +41,8 @@ class ArgumentValueNormalizerTest extends TestCase
     /** @test */
     public function it_normalizes_closures_to_classname()
     {
-        $closure = function ($something) {};
+        $closure = function ($something) {
+        };
         $this->assertEquals(Closure::class, ArgumentValueNormalizer::normalize($closure));
     }
 
@@ -59,7 +60,6 @@ class ArgumentValueNormalizerTest extends TestCase
         $this->assertContains('b', $keys);
         $this->assertNotContains('c', $keys);
         $this->assertNotContains('d', $keys);
-
 
         $normalizer = new class extends ArgumentValueNormalizer {
             protected const MAX_KEYS_IN_ARRAY = 1;
@@ -87,10 +87,10 @@ class ArgumentValueNormalizerTest extends TestCase
                     'c' => new stdClass(),
                     'd' => 1,
                     'e' => [
-                        'f' => 3
-                    ]
+                        'f' => 3,
+                    ],
                 ]
-            ]
+            ],
         ];
         $normalized = $normalizer::normalize($array);
         $expected = [
@@ -99,8 +99,8 @@ class ArgumentValueNormalizerTest extends TestCase
                     'c' => stdClass::class,
                     'd' => 1,
                     'e' => 'Array(1 item)',
-                ]
-            ]
+                ],
+            ],
         ];
         $this->assertEquals($expected, $normalized);
 
@@ -115,16 +115,16 @@ class ArgumentValueNormalizerTest extends TestCase
                     'c' => new stdClass(),
                     'd' => 1,
                     'e' => [
-                        'f' => 3
-                    ]
-                ]
-            ]
+                        'f' => 3,
+                    ],
+                ],
+            ],
         ];
         $normalized = $normalizer::normalize($array);
         $expected = [
             'a' => [
                 'b' => 'Array(3 items)',
-            ]
+            ],
         ];
         $this->assertEquals($expected, $normalized);
     }

--- a/tests/ArgumentValueNormalizerTest.php
+++ b/tests/ArgumentValueNormalizerTest.php
@@ -89,7 +89,7 @@ class ArgumentValueNormalizerTest extends TestCase
                     'e' => [
                         'f' => 3,
                     ],
-                ]
+                ],
             ],
         ];
         $normalized = $normalizer::normalize($array);
@@ -103,7 +103,6 @@ class ArgumentValueNormalizerTest extends TestCase
             ],
         ];
         $this->assertEquals($expected, $normalized);
-
 
         $normalizer = new class extends ArgumentValueNormalizer {
             protected const MAX_DEPTH = 1;

--- a/tests/ArgumentValueNormalizerTest.php
+++ b/tests/ArgumentValueNormalizerTest.php
@@ -127,5 +127,4 @@ class ArgumentValueNormalizerTest extends TestCase
         ];
         $this->assertEquals($expected, $normalized);
     }
-
 }

--- a/tests/ArgumentValueNormalizerTest.php
+++ b/tests/ArgumentValueNormalizerTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Honeybadger\Tests;
+
+use Closure;
+use Honeybadger\ArgumentValueNormalizer;
+use Honeybadger\Honeybadger;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class ArgumentValueNormalizerTest extends TestCase
+{
+    /** @test */
+    public function it_normalizes_simple_primitives_as_they_are()
+    {
+        $integer = rand();
+        $this->assertEquals($integer, ArgumentValueNormalizer::normalize($integer));
+
+        $float = rand() / rand();
+        $this->assertEquals($float, ArgumentValueNormalizer::normalize($float));
+
+        $string = substr(str_shuffle('ABCDEFGHIJKLMNOPQRSTUVWXYZ'), 0, 13);
+        $this->assertEquals($string, ArgumentValueNormalizer::normalize($string));
+
+        $this->assertEquals(false, ArgumentValueNormalizer::normalize(false));
+        $this->assertEquals(true, ArgumentValueNormalizer::normalize(true));
+
+        $array = [rand(), $string];
+        $this->assertEquals($array, ArgumentValueNormalizer::normalize($array));
+    }
+
+    /** @test */
+    public function it_normalizes_objects_to_classname()
+    {
+        $obj = new stdClass();
+        $honeybadger = new Honeybadger([]);
+        $this->assertEquals(stdClass::class, ArgumentValueNormalizer::normalize($obj));
+        $this->assertEquals(Honeybadger::class, ArgumentValueNormalizer::normalize($honeybadger));
+    }
+
+    /** @test */
+    public function it_normalizes_closures_to_classname()
+    {
+        $closure = function ($something) {};
+        $this->assertEquals(Closure::class, ArgumentValueNormalizer::normalize($closure));
+    }
+
+    /** @test */
+    public function it_limits_number_of_keys_in_array()
+    {
+        $normalizer = new class extends ArgumentValueNormalizer {
+            protected const MAX_KEYS_IN_ARRAY = 2;
+        };
+
+        $array = ['a' => 18567, 'b' => '97ndfs', 'c' => 97874, 'd' => 'hehehe'];
+        $keys = array_keys($normalizer::normalize($array));
+        $this->assertCount(2, $keys);
+        $this->assertContains('a', $keys);
+        $this->assertContains('b', $keys);
+        $this->assertNotContains('c', $keys);
+        $this->assertNotContains('d', $keys);
+
+
+        $normalizer = new class extends ArgumentValueNormalizer {
+            protected const MAX_KEYS_IN_ARRAY = 1;
+        };
+
+        $array = ['a' => 18567, 'b' => '97ndfs', 'c' => 97874, 'd' => 'hehehe'];
+        $keys = array_keys($normalizer::normalize($array));
+        $this->assertCount(1, $keys);
+        $this->assertContains('a', $keys);
+        $this->assertNotContains('b', $keys);
+        $this->assertNotContains('c', $keys);
+        $this->assertNotContains('d', $keys);
+    }
+
+    /** @test */
+    public function it_limits_array_depth()
+    {
+        $normalizer = new class extends ArgumentValueNormalizer {
+            protected const MAX_DEPTH = 2;
+        };
+
+        $array = [
+            'a' => [
+                'b' => [
+                    'c' => new stdClass(),
+                    'd' => 1,
+                    'e' => [
+                        'f' => 3
+                    ]
+                ]
+            ]
+        ];
+        $normalized = $normalizer::normalize($array);
+        $expected = [
+            'a' => [
+                'b' => [
+                    'c' => stdClass::class,
+                    'd' => 1,
+                    'e' => 'Array(1 item)',
+                ]
+            ]
+        ];
+        $this->assertEquals($expected, $normalized);
+
+
+        $normalizer = new class extends ArgumentValueNormalizer {
+            protected const MAX_DEPTH = 1;
+        };
+
+        $array = [
+            'a' => [
+                'b' => [
+                    'c' => new stdClass(),
+                    'd' => 1,
+                    'e' => [
+                        'f' => 3
+                    ]
+                ]
+            ]
+        ];
+        $normalized = $normalizer::normalize($array);
+        $expected = [
+            'a' => [
+                'b' => 'Array(3 items)',
+            ]
+        ];
+        $this->assertEquals($expected, $normalized);
+    }
+
+}


### PR DESCRIPTION
## Status
**READY**

## Description
This PR introduces an `ArgumentValueNormalizer` class, whose job is to "normalise" arguments before they are serialised and sent to Honeybadger.

The `ArgumentValueNormalizer` will normalize each kind of value properly. For instance:
- For objects, it will replace them with the class name (or whatever we switch to after #133 ).
- For arrays, it will normalize each item up to a maximum number of keys and maximum nesting depth in order to limit the backtrace size. Here's what an array truncated due to excessive nesting looks like:

![image](https://user-images.githubusercontent.com/14361073/108946513-da83b480-765e-11eb-88c6-34b734ba4237.png)

Currently the defaults are 50 keys per array and a max depth of 10. @stympy let me know if this makes sense.