### PR TITLE
Render objects as literals (fixes #133)

### DIFF
--- a/src/ArgumentValueNormalizer.php
+++ b/src/ArgumentValueNormalizer.php
@@ -51,12 +51,11 @@ class ArgumentValueNormalizer
         return $normalized;
     }
 
-    /**
-     * Currently, objects are normalized to the class name. This isn't ideal (see GH issue 133),
-     * but we can change it at any time.
-     */
-    protected static function normalizeObject(object $object)
+    protected static function normalizeObject(object $object): string
     {
-        return get_class($object);
+        $class = get_class($object);
+
+        // The [LITERAL] token indicates to the Honeybadger UI that this value should be rendered as-is, without any surrounding quotes. See GH#133.
+        return "[LITERAL]Object($class)";
     }
 }

--- a/src/ArgumentValueNormalizer.php
+++ b/src/ArgumentValueNormalizer.php
@@ -55,7 +55,7 @@ class ArgumentValueNormalizer
     {
         $class = get_class($object);
 
-        // The [LITERAL] token indicates to the Honeybadger UI that this value should be rendered as-is, without any surrounding quotes. See GH#133.
+        // The [LITERAL] token indicates to the Honeybadger UI that this value should be rendered as-is, without any surrounding quotes. See issue #133.
         return "[LITERAL]Object($class)";
     }
 }

--- a/tests/ArgumentValueNormalizerTest.php
+++ b/tests/ArgumentValueNormalizerTest.php
@@ -30,12 +30,12 @@ class ArgumentValueNormalizerTest extends TestCase
     }
 
     /** @test */
-    public function it_normalizes_objects_to_classname()
+    public function it_normalizes_objects_to_literal()
     {
         $obj = new stdClass();
         $honeybadger = new Honeybadger([]);
-        $this->assertEquals(stdClass::class, ArgumentValueNormalizer::normalize($obj));
-        $this->assertEquals(Honeybadger::class, ArgumentValueNormalizer::normalize($honeybadger));
+        $this->assertEquals('[LITERAL]Object('.stdClass::class.')', ArgumentValueNormalizer::normalize($obj));
+        $this->assertEquals('[LITERAL]Object('.Honeybadger::class.')', ArgumentValueNormalizer::normalize($honeybadger));
     }
 
     /** @test */
@@ -43,7 +43,7 @@ class ArgumentValueNormalizerTest extends TestCase
     {
         $closure = function ($something) {
         };
-        $this->assertEquals(Closure::class, ArgumentValueNormalizer::normalize($closure));
+        $this->assertEquals('[LITERAL]Object('.Closure::class.')', ArgumentValueNormalizer::normalize($closure));
     }
 
     /** @test */
@@ -94,7 +94,7 @@ class ArgumentValueNormalizerTest extends TestCase
         $expected = [
             'a' => [
                 'b' => [
-                    'c' => stdClass::class,
+                    'c' => "[LITERAL]Object(stdClass)",
                     'd' => 1,
                     'e' => 'Array(1 item)',
                 ],

--- a/tests/ArgumentValueNormalizerTest.php
+++ b/tests/ArgumentValueNormalizerTest.php
@@ -30,7 +30,7 @@ class ArgumentValueNormalizerTest extends TestCase
     }
 
     /** @test */
-    public function it_normalizes_objects_to_literal()
+    public function it_normalizes_objects_to_literals()
     {
         $obj = new stdClass();
         $honeybadger = new Honeybadger([]);
@@ -39,7 +39,7 @@ class ArgumentValueNormalizerTest extends TestCase
     }
 
     /** @test */
-    public function it_normalizes_closures_to_classname()
+    public function it_normalizes_closures_to_literals()
     {
         $closure = function ($something) {
         };
@@ -94,7 +94,7 @@ class ArgumentValueNormalizerTest extends TestCase
         $expected = [
             'a' => [
                 'b' => [
-                    'c' => "[LITERAL]Object(stdClass)",
+                    'c' => '[LITERAL]Object(stdClass)',
                     'd' => 1,
                     'e' => 'Array(1 item)',
                 ],

--- a/tests/BacktraceFactoryTest.php
+++ b/tests/BacktraceFactoryTest.php
@@ -141,7 +141,7 @@ class BacktraceFactoryTest extends TestCase
     }
 
     /** @test */
-    public function args_with_object_should_be_class_names()
+    public function args_with_object_should_be_literals()
     {
         $throwTestException = function ($foo, $bar) {
             throw new Exception('test');
@@ -154,7 +154,7 @@ class BacktraceFactoryTest extends TestCase
         }
 
         $this->assertEquals('Honeybadger\Tests\{closure}', $backtrace[0]['method']);
-        $this->assertEquals(['bar', TestClass::class], $backtrace[0]['args']);
+        $this->assertEquals(['bar', '[LITERAL]Object('.TestClass::class.')'], $backtrace[0]['args']);
     }
 }
 


### PR DESCRIPTION
## Status
**READY**

## Description
See https://github.com/honeybadger-io/honeybadger-php/issues/133

This PR renders objects in backtrace arguments as `"[LITERAL]Object(<classname>)"` (example: `"[LITERAL]Object(Illuminate\Http\Request)"`. The `[LITERAL]` token signals to the Honeybadger UI that this should be rendered as-is, without any quotes.
