### PR TITLE
add array support to context method and allow chaining

### DIFF
--- a/src/Contracts/Reporter.php
+++ b/src/Contracts/Reporter.php
@@ -43,9 +43,9 @@ interface Reporter
     public function checkin(string $key): void;
 
     /**
-     * @param  int|string  $key
-     * @param  int|string  $value
-     * @return void
+     * @param  int|string|array  $key
+     * @param  int|string|array|null  $value
+     * @return self
      */
-    public function context($key, $value): void;
+    public function context($key, $value): self;
 }

--- a/src/Contracts/Reporter.php
+++ b/src/Contracts/Reporter.php
@@ -45,7 +45,7 @@ interface Reporter
     /**
      * @param  int|string|array  $key
      * @param  int|string|array|null  $value
-     * @return Reporter
+     * @return self
      */
-    public function context($key, $value = null): Reporter;
+    public function context($key, $value = null);
 }

--- a/src/Contracts/Reporter.php
+++ b/src/Contracts/Reporter.php
@@ -43,8 +43,10 @@ interface Reporter
     public function checkin(string $key): void;
 
     /**
+     * Accepts a $key and $value argument or alternatively a key-value array as sole $key argument.
+     *
      * @param  int|string|array  $key
-     * @param  int|string|array|null  $value
+     * @param  mixed  $value
      * @return self
      */
     public function context($key, $value = null);

--- a/src/Contracts/Reporter.php
+++ b/src/Contracts/Reporter.php
@@ -43,7 +43,7 @@ interface Reporter
     public function checkin(string $key): void;
 
     /**
-     * Accepts a $key and $value argument or alternatively a key-value array as sole $key argument.
+     * Attach some additional context to an error report. Context can be specified as a $key and $value, or as an array with key-value pairs.
      *
      * @param  int|string|array  $key
      * @param  mixed  $value

--- a/src/Contracts/Reporter.php
+++ b/src/Contracts/Reporter.php
@@ -45,7 +45,7 @@ interface Reporter
     /**
      * @param  int|string|array  $key
      * @param  int|string|array|null  $value
-     * @return self
+     * @return Reporter
      */
-    public function context($key, $value = null): self;
+    public function context($key, $value = null): Reporter;
 }

--- a/src/Contracts/Reporter.php
+++ b/src/Contracts/Reporter.php
@@ -47,5 +47,5 @@ interface Reporter
      * @param  int|string|array|null  $value
      * @return self
      */
-    public function context($key, $value): self;
+    public function context($key, $value = null): self;
 }

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -109,28 +109,23 @@ class Honeybadger implements Reporter
     }
 
     /**
-     * Adds multiple pieces of context.
+     * Accepts a key and value argument or alternatively a key-value array as sole argument
      *
-     * @param  array  $context
+     * @param  int|string|array  $key
+     * @param  int|string|array|null  $value
      * @return self
      */
-    public function withContext(array $context): self
+    public function context($key, $value = null): self
     {
-        foreach ($context as $key => $value) {
-            $this->context($key, $value);
+        if (is_array($key)) {
+            foreach ($key as $contextKey => $contextValue) {
+                $this->context->set($contextKey, $contextValue);
+            }
+        } else {
+            $this->context->set($key, $value);
         }
 
         return $this;
-    }
-
-    /**
-     * @param  int|string  $key
-     * @param  int|string|array  $value
-     * @return void
-     */
-    public function context($key, $value): void
-    {
-        $this->context->set($key, $value);
     }
 
     /**

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -109,12 +109,12 @@ class Honeybadger implements Reporter
     }
 
     /**
-     * Adds multiple pieces of context
+     * Adds multiple pieces of context.
      *
      * @param  array  $context
      * @return self
      */
-    public function withContext(array $context) : self
+    public function withContext(array $context): self
     {
         foreach ($context as $key => $value) {
             $this->context($key, $value);

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -109,6 +109,21 @@ class Honeybadger implements Reporter
     }
 
     /**
+     * Adds multiple pieces of context
+     *
+     * @param  array  $context
+     * @return self
+     */
+    public function withContext(array $context) : self
+    {
+        foreach ($context as $key => $value) {
+            $this->context($key, $value);
+        }
+
+        return $this;
+    }
+
+    /**
      * @param  int|string  $key
      * @param  int|string|array  $value
      * @return void

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -109,7 +109,7 @@ class Honeybadger implements Reporter
     }
 
     /**
-     * Accepts a key and value argument or alternatively a key-value array as sole argument
+     * Accepts a key and value argument or alternatively a key-value array as sole argument.
      *
      * @param  int|string|array  $key
      * @param  int|string|array|null  $value

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -113,9 +113,9 @@ class Honeybadger implements Reporter
      *
      * @param  int|string|array  $key
      * @param  int|string|array|null  $value
-     * @return Reporter
+     * @return self
      */
-    public function context($key, $value = null): Reporter
+    public function context($key, $value = null)
     {
         if (is_array($key)) {
             foreach ($key as $contextKey => $contextValue) {

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -113,9 +113,9 @@ class Honeybadger implements Reporter
      *
      * @param  int|string|array  $key
      * @param  int|string|array|null  $value
-     * @return self
+     * @return Reporter
      */
-    public function context($key, $value = null): self
+    public function context($key, $value = null): Reporter
     {
         if (is_array($key)) {
             foreach ($key as $contextKey => $contextValue) {

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -109,11 +109,7 @@ class Honeybadger implements Reporter
     }
 
     /**
-     * Accepts a key and value argument or alternatively a key-value array as sole argument.
-     *
-     * @param  int|string|array  $key
-     * @param  int|string|array|null  $value
-     * @return self
+     * {@inheritdoc}
      */
     public function context($key, $value = null)
     {

--- a/tests/HoneyBadgerTest.php
+++ b/tests/HoneyBadgerTest.php
@@ -116,7 +116,7 @@ class HoneyBadgerTest extends TestCase
             ],
         ], $client->make());
 
-        $badger->withContext([
+        $badger->context([
             'foo' => 'bar',
             'another' => 'context',
         ]);
@@ -132,7 +132,7 @@ class HoneyBadgerTest extends TestCase
     }
 
     /** @test */
-    public function with_context_method_returns_honeybadger_instance()
+    public function context_method_returns_honeybadger_instance()
     {
         $client = HoneybadgerClient::new([
             new Response(201),
@@ -146,7 +146,7 @@ class HoneyBadgerTest extends TestCase
             ],
         ], $client->make());
 
-        $this->assertEquals($badger, $badger->withContext([
+        $this->assertEquals($badger, $badger->context([
             'foo' => 'bar',
             'another' => 'context',
         ]));

--- a/tests/HoneyBadgerTest.php
+++ b/tests/HoneyBadgerTest.php
@@ -104,6 +104,57 @@ class HoneyBadgerTest extends TestCase
     }
 
     /** @test */
+    public function it_accepts_and_sends_multiple_pieces_of_context()
+    {
+        $client = HoneybadgerClient::new([
+            new Response(201),
+        ]);
+
+        $badger = Honeybadger::new([
+            'api_key' => 'asdf',
+            'handlers' => [
+                'exception' => false,
+                'error' => false,
+            ],
+        ], $client->make());
+
+        $badger->withContext([
+            'foo' => 'bar',
+            'another' => 'context',
+        ]);
+
+        $response = $badger->notify(new Exception('Test exception'));
+
+        $notification = $client->requestBody();
+
+        $this->assertEquals([
+            'foo' => 'bar',
+            'another' => 'context',
+        ], $notification['request']['context']);
+    }
+
+    /** @test */
+    public function with_context_method_returns_honeybadger_instance()
+    {
+        $client = HoneybadgerClient::new([
+            new Response(201),
+        ]);
+
+        $badger = Honeybadger::new([
+            'api_key' => 'asdf',
+            'handlers' => [
+                'exception' => false,
+                'error' => false,
+            ],
+        ], $client->make());
+
+        $this->assertEquals($badger, $badger->withContext([
+            'foo' => 'bar',
+            'another' => 'context',
+        ]));
+    }
+
+    /** @test */
     public function it_filters_and_includes_environment_keys_by_config()
     {
         $client = HoneybadgerClient::new([

--- a/tests/HoneyBadgerTest.php
+++ b/tests/HoneyBadgerTest.php
@@ -132,7 +132,7 @@ class HoneyBadgerTest extends TestCase
     }
 
     /** @test */
-    public function context_method_returns_honeybadger_instance()
+    public function it_accepts_and_sends_chained_contexts()
     {
         $client = HoneybadgerClient::new([
             new Response(201),
@@ -146,10 +146,24 @@ class HoneyBadgerTest extends TestCase
             ],
         ], $client->make());
 
-        $this->assertEquals($badger, $badger->context([
+        $badger->context([
             'foo' => 'bar',
             'another' => 'context',
-        ]));
+        ])->context([
+            'chained-foo' => 'chained-bar',
+            'chained-another' => 'chained-context',
+        ]);
+
+        $response = $badger->notify(new Exception('Test exception'));
+
+        $notification = $client->requestBody();
+
+        $this->assertEquals([
+            'foo' => 'bar',
+            'another' => 'context',
+            'chained-foo' => 'chained-bar',
+            'chained-another' => 'chained-context',
+        ], $notification['request']['context']);
     }
 
     /** @test */


### PR DESCRIPTION
## Status
READY

## Description
This PR will make it easier to add an array of context values, it also opens up for chaining.

The PR includes tests.

**Before**

```php
foreach ($array as $key => $value) {
    $honeybadger->context($key, $value);
}
```

**After**

```php
$honeybadger->withContext($array);
```

And the chaining will allow the exception handler to look something like this (my example is for Laravel).

**Before**

```php
$honeybadger = $this->container->make('honeybadger');

foreach ($array as $key => $value) {
    $honeybadger->context($key, $value);
}

$honeybadger->notify($e);
```

**After**

```php
$this->container->make('honeybadger')
    ->withContext($array)
    ->notify($e);
```
