### PR TITLE
JSON-encode empty arrays properly

### DIFF
--- a/src/ExceptionNotification.php
+++ b/src/ExceptionNotification.php
@@ -4,6 +4,7 @@ namespace Honeybadger;
 
 use Honeybadger\Support\Arr;
 use Honeybadger\Support\Repository;
+use stdClass;
 use Symfony\Component\HttpFoundation\Request as FoundationRequest;
 use Throwable;
 
@@ -87,11 +88,12 @@ class ExceptionNotification
                 'tags' => Arr::wrap(Arr::get($this->additionalParams, 'tags', null)),
             ],
             'request' => [
-                'cgi_data' => $this->environment->values(),
-                'params' => $this->request->params(),
-                'session' => $this->request->session(),
+                // Important to set empty maps to stdClass so they don't get JSON-encoded as arrays
+                'cgi_data' => $this->environment->values() ?: new stdClass,
+                'params' => $this->request->params() ?: new stdClass,
+                'session' => $this->request->session() ?: new stdClass,
                 'url' => $this->request->url(),
-                'context' => $this->context->except(['honeybadger_component', 'honeybadger_action']),
+                'context' => $this->context->except(['honeybadger_component', 'honeybadger_action']) ?: new stdClass,
                 'component' => Arr::get($this->additionalParams, 'component', null) ?? Arr::get($this->context, 'honeybadger_component', null),
                 'action' => Arr::get($this->additionalParams, 'action', null) ?? Arr::get($this->context, 'honeybadger_action', null),
             ],

--- a/tests/HoneyBadgerTest.php
+++ b/tests/HoneyBadgerTest.php
@@ -84,7 +84,6 @@ class HoneyBadgerTest extends TestCase
     {
         $client = HoneybadgerClient::new([
             new Response(201),
-            new Response(201),
         ]);
 
         $badger = Honeybadger::new([
@@ -106,7 +105,6 @@ class HoneyBadgerTest extends TestCase
     public function it_json_encodes_empty_request_data_properly()
     {
         $client = HoneybadgerClient::new([
-            new Response(201),
             new Response(201),
         ]);
 

--- a/tests/HoneyBadgerTest.php
+++ b/tests/HoneyBadgerTest.php
@@ -84,6 +84,7 @@ class HoneyBadgerTest extends TestCase
     {
         $client = HoneybadgerClient::new([
             new Response(201),
+            new Response(201),
         ]);
 
         $badger = Honeybadger::new([
@@ -96,11 +97,32 @@ class HoneyBadgerTest extends TestCase
 
         $badger->context('foo', 'bar');
 
-        $response = $badger->notify(new Exception('Test exception'));
-
+        $badger->notify(new Exception('Test exception'));
         $notification = $client->requestBody();
-
         $this->assertEquals(['foo' => 'bar'], $notification['request']['context']);
+    }
+
+    /** @test */
+    public function it_json_encodes_empty_request_data_properly()
+    {
+        $client = HoneybadgerClient::new([
+            new Response(201),
+            new Response(201),
+        ]);
+
+        $badger = Honeybadger::new([
+            'api_key' => 'asdf',
+            'handlers' => [
+                'exception' => false,
+                'error' => false,
+            ],
+        ], $client->make());
+
+        $badger->notify(new Exception('Test exception'));
+        $requestBody = $client->calls()[0]['request']->getBody()->getContents();
+        $this->assertStringContainsString('"context":{}', $requestBody);
+        $this->assertStringContainsString('"params":{}', $requestBody);
+        $this->assertStringContainsString('"session":{}', $requestBody);
     }
 
     /** @test */

--- a/tests/Mocks/HoneybadgerClient.php
+++ b/tests/Mocks/HoneybadgerClient.php
@@ -13,6 +13,7 @@ class HoneybadgerClient extends Client
     {
         if ($calls = $this->calls()) {
             $lastCall = $calls[count($calls) - 1];
+
             return json_decode($lastCall['request']->getBody(), true);
         }
 

--- a/tests/Mocks/HoneybadgerClient.php
+++ b/tests/Mocks/HoneybadgerClient.php
@@ -11,8 +11,11 @@ class HoneybadgerClient extends Client
 
     public function requestBody()
     {
-        return $this->calls()
-            ? json_decode($this->calls()[0]['request']->getBody(), true)
-            : null;
+        if ($calls = $this->calls()) {
+            $lastCall = $calls[count($calls) - 1];
+            return json_decode($lastCall['request']->getBody(), true);
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Status
**READY**

## Description
See #137 — /PHP's multitasking arrays (they're lists, maps, and everything in between) strike again! Fixed by setting the key to an object rather than array when empty.