### PR TITLE
Add breadcrumbs functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.3|^7.0.1",
         "monolog/monolog": "^2.0",
-        "spatie/ray": "^1.20",
         "spatie/regex": "^1.4",
         "symfony/http-foundation": ">=3.3|^4.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,11 @@
         }
     ],
     "require": {
-        "ext-json": "*",
         "php": "^7.2|^8.0",
+        "ext-json": "*",
         "guzzlehttp/guzzle": "^6.3|^7.0.1",
         "monolog/monolog": "^2.0",
+        "spatie/ray": "^1.20",
         "spatie/regex": "^1.4",
         "symfony/http-foundation": ">=3.3|^4.1"
     },

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -31,7 +31,7 @@ class Breadcrumbs extends EvictingQueue
         $sanitized = [];
         foreach ($data as $key => $value) {
             if (is_array($value) || is_object($value) || is_resource($value)) {
-                continue;
+                $value = "[DEPTH]";
             }
 
             if (is_string($value)) {

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Honeybadger;
+
+use Honeybadger\Support\EvictingQueue;
+
+class Breadcrumbs extends EvictingQueue
+{
+    /**
+     * @param $item
+     *
+     * @return self
+     */
+    public function add($item)
+    {
+        $item = [
+            'message' => (string) $item['message'],
+            'category' => (string) ($item['category'] ?? 'custom'),
+            'metadata' => $this->sanitize($item['metadata'] ?? []),
+            'timestamp' => $item['timestamp'] ?? time(),
+        ];
+
+        return parent::add($item);
+    }
+
+    /**
+     * Limit an array to a simple [key => value] (one level) containing only primitives.
+     */
+    private function sanitize(array $data): array
+    {
+        $sanitized = [];
+        foreach ($data as $key => $value) {
+            if (is_array($value) || is_object($value) || is_resource($value)) {
+                continue;
+            }
+
+            if (is_string($value)) {
+                // Limit strings to 64kB.
+                $value = substr($value, 0, 64000);
+            }
+
+            $sanitized[$key] = $value;
+        }
+
+        return $sanitized;
+    }
+}

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -31,7 +31,7 @@ class Breadcrumbs extends EvictingQueue
         $sanitized = [];
         foreach ($data as $key => $value) {
             if (is_array($value) || is_object($value) || is_resource($value)) {
-                $value = "[DEPTH]";
+                $value = '[DEPTH]';
             }
 
             if (is_string($value)) {

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -17,7 +17,7 @@ class Breadcrumbs extends EvictingQueue
             'message' => (string) $item['message'],
             'category' => (string) ($item['category'] ?? 'custom'),
             'metadata' => $this->sanitize($item['metadata'] ?? []),
-            'timestamp' => $item['timestamp'] ?? time(),
+            'timestamp' => (int) ($item['timestamp'] ?? time()),
         ];
 
         return parent::add($item);

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -17,7 +17,7 @@ class Breadcrumbs extends EvictingQueue
             'message' => (string) $item['message'],
             'category' => (string) ($item['category'] ?? 'custom'),
             'metadata' => $this->sanitize($item['metadata'] ?? []),
-            'timestamp' => (int) ($item['timestamp'] ?? time()),
+            'timestamp' => $item['timestamp'] ?? date('c'),
         ];
 
         return parent::add($item);

--- a/src/Config.php
+++ b/src/Config.php
@@ -57,6 +57,8 @@ class Config extends Repository
             'vendor_paths' => [
                 'vendor\/.*',
             ],
+            'breadcrumbs_enabled' => true,
+            'max_breadcrumbs' => 40,
         ], $config);
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -57,8 +57,10 @@ class Config extends Repository
             'vendor_paths' => [
                 'vendor\/.*',
             ],
-            'breadcrumbs_enabled' => true,
-            'max_breadcrumbs' => 40,
+            'breadcrumbs' => [
+                'enabled' => true,
+                'keep' => 40,
+            ],
         ], $config);
     }
 }

--- a/src/Contracts/Reporter.php
+++ b/src/Contracts/Reporter.php
@@ -50,4 +50,25 @@ interface Reporter
      * @return self
      */
     public function context($key, $value = null);
+
+    /**
+     * Add a breadcrumb item.
+     *
+     * Breadcrumbs are records of events that happen within your app.
+     * A breadcrumb might be anything, such as a database query, log entry or external API call.
+     * Breadcrumbs can be useful when debugging, as they help you understand what events led up to an error.
+     * Our framework integrations will automatically add some breadcrumbs, but you can add yours manually with this method.
+     *
+     * @param string $message A brief description of the event represented by this breadcrumb, for example "Email Sent".
+     * @param array $metadata A map of contextual data about the event. This must be a simple key-value array at one level (no nesting allowed).
+     * @param string $category A key for grouping related events. You can use anything here, but we recommend following the list at https://docs.honeybadger.io/lib/ruby/getting-started/breadcrumbs.html#categories.
+     *
+     * @return $this
+     */
+    public function addBreadcrumb(string $message, array $metadata = [], string $category = 'custom'): self;
+
+    /**
+     * Clear all breadcrumbs and context.
+     */
+    public function clear(): self;
 }

--- a/src/Contracts/Reporter.php
+++ b/src/Contracts/Reporter.php
@@ -61,7 +61,7 @@ interface Reporter
      *
      * @param string $message A brief description of the event represented by this breadcrumb, for example "Email Sent".
      * @param array $metadata A map of contextual data about the event. This must be a simple key-value array at one level (no nesting allowed).
-     * @param string $category A key for grouping related events. You can use anything here, but we recommend following the list at https://docs.honeybadger.io/lib/ruby/getting-started/breadcrumbs.html#categories.
+     * @param string $category A key for grouping related events. You can use anything here, but we recommend following the list at https://docs.honeybadger.io/lib/php/guides/breadcrumbs.html#categories.
      *
      * @return $this
      */

--- a/src/ExceptionNotification.php
+++ b/src/ExceptionNotification.php
@@ -86,7 +86,7 @@ class ExceptionNotification
     {
         return [
             'breadcrumbs' => [
-                'enabled' => $this->config['breadcrumbs_enabled'],
+                'enabled' => $this->config['breadcrumbs']['enabled'],
                 'trail' => $this->breadcrumbs->toArray(),
             ],
             'notifier' => $this->config['notifier'],

--- a/src/ExceptionNotification.php
+++ b/src/ExceptionNotification.php
@@ -85,7 +85,10 @@ class ExceptionNotification
     private function format(): array
     {
         return [
-            'breadcrumbs' => $this->breadcrumbs->toArray(),
+            'breadcrumbs' => [
+                'enabled' => $this->config['breadcrumbs_enabled'],
+                'trail' => $this->breadcrumbs->toArray(),
+            ],
             'notifier' => $this->config['notifier'],
             'error' => [
                 'class' => get_class($this->throwable),

--- a/src/ExceptionNotification.php
+++ b/src/ExceptionNotification.php
@@ -21,6 +21,11 @@ class ExceptionNotification
     protected $context;
 
     /**
+     * @var \Honeybadger\Breadcrumbs
+     */
+    protected $breadcrumbs;
+
+    /**
      * @var \Throwable
      */
     protected $throwable;
@@ -46,13 +51,15 @@ class ExceptionNotification
     protected $additionalParams;
 
     /**
-     * @param  \Honeybadger\Config  $config
-     * @param  \Honeybadger\Support\Repository  $context
+     * @param \Honeybadger\Config $config
+     * @param \Honeybadger\Support\Repository $context
+     * @param \Honeybadger\Breadcrumbs $breadcrumbs
      */
-    public function __construct(Config $config, Repository $context)
+    public function __construct(Config $config, Repository $context, Breadcrumbs $breadcrumbs)
     {
         $this->config = $config;
         $this->context = $context;
+        $this->breadcrumbs = $breadcrumbs;
     }
 
     /**
@@ -78,6 +85,7 @@ class ExceptionNotification
     private function format(): array
     {
         return [
+            'breadcrumbs' => $this->breadcrumbs->toArray(),
             'notifier' => $this->config['notifier'],
             'error' => [
                 'class' => get_class($this->throwable),

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -56,7 +56,7 @@ class Honeybadger implements Reporter
 
         $this->client = new HoneybadgerClient($this->config, $client);
         $this->context = new Repository;
-        $this->breadcrumbs = new Breadcrumbs($this->config['max_breadcrumbs']);
+        $this->breadcrumbs = new Breadcrumbs($this->config['breadcrumbs']['keep'] ?? 40);
 
         $this->setHandlers();
     }
@@ -72,7 +72,7 @@ class Honeybadger implements Reporter
 
         $notification = new ExceptionNotification($this->config, $this->context, $this->breadcrumbs);
 
-        if ($this->config['breadcrumbs_enabled']) {
+        if ($this->config['breadcrumbs']['enabled']) {
             $this->addBreadcrumb('Honeybadger Notice', [
                 'message' => $throwable->getMessage(),
                 'name' => get_class($throwable),
@@ -148,7 +148,7 @@ class Honeybadger implements Reporter
 
     public function addBreadcrumb(string $message, array $metadata = [], string $category = 'custom'): Reporter
     {
-        if ($this->config['breadcrumbs_enabled']) {
+        if ($this->config['breadcrumbs']['enabled']) {
             $this->breadcrumbs->add([
                 'message' => $message,
                 'metadata' => $metadata,

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -152,7 +152,7 @@ class Honeybadger implements Reporter
             $this->breadcrumbs->add([
                 'message' => $message,
                 'metadata' => $metadata,
-                'category' => $category
+                'category' => $category,
             ]);
         }
 

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -42,6 +42,11 @@ class Honeybadger implements Reporter
     protected $context;
 
     /**
+     * @var \Honeybadger\Breadcrumbs
+     */
+    protected $breadcrumbs;
+
+    /**
      * @param  array  $config
      * @param  \GuzzleHttp\Client  $client
      */
@@ -51,6 +56,7 @@ class Honeybadger implements Reporter
 
         $this->client = new HoneybadgerClient($this->config, $client);
         $this->context = new Repository;
+        $this->breadcrumbs = new Breadcrumbs($this->config['max_breadcrumbs']);
 
         $this->setHandlers();
     }
@@ -64,10 +70,18 @@ class Honeybadger implements Reporter
             return [];
         }
 
-        $notification = (new ExceptionNotification($this->config, $this->context))
-            ->make($throwable, $request, $additionalParams);
+        $notification = new ExceptionNotification($this->config, $this->context, $this->breadcrumbs);
 
-        return $this->client->notification($notification);
+        if ($this->config['breadcrumbs_enabled']) {
+            $this->addBreadcrumb('Honeybadger Notice', [
+                'message' => $throwable->getMessage(),
+                'name' => get_class($throwable),
+            ], 'notice');
+        }
+
+        return $this->client->notification(
+            $notification->make($throwable, $request, $additionalParams)
+        );
     }
 
     /**
@@ -130,6 +144,27 @@ class Honeybadger implements Reporter
     public function resetContext(): void
     {
         $this->context = new Repository;
+    }
+
+    public function addBreadcrumb(string $message, array $metadata = [], string $category = 'custom'): Reporter
+    {
+        if ($this->config['breadcrumbs_enabled']) {
+            $this->breadcrumbs->add([
+                'message' => $message,
+                'metadata' => $metadata,
+                'category' => $category
+            ]);
+        }
+
+        return $this;
+    }
+
+    public function clear(): Reporter
+    {
+        $this->context = new Repository;
+        $this->breadcrumbs->clear();
+
+        return $this;
     }
 
     /**

--- a/src/Support/EvictingQueue.php
+++ b/src/Support/EvictingQueue.php
@@ -3,7 +3,7 @@
 namespace Honeybadger\Support;
 
 /**
- * A container to hold an ordered list of items, automatically evicting older items to maintain a specified maximum size.
+ * A container to hold an ordered list of items, automatically evicting older items to maintain a specified maximum capacity.
  */
 class EvictingQueue
 {
@@ -15,11 +15,11 @@ class EvictingQueue
     /**
      * @var int
      */
-    protected $size;
+    protected $capacity;
 
-    public function __construct(int $size, array $items = [])
+    public function __construct(int $capacity, array $items = [])
     {
-        $this->size = $size;
+        $this->capacity = $capacity;
         $this->items = $items;
     }
 
@@ -32,7 +32,7 @@ class EvictingQueue
     {
         $this->items[] = $item;
 
-        if (count($this->items) > $this->size) {
+        if (count($this->items) > $this->capacity) {
             array_shift($this->items);
         }
 

--- a/src/Support/EvictingQueue.php
+++ b/src/Support/EvictingQueue.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Honeybadger\Support;
+
+/**
+ * A container to hold an ordered list of items, automatically evicting older items to maintain a specified maximum size.
+ */
+class EvictingQueue
+{
+    /**
+     * @var array
+     */
+    protected $items = [];
+
+    /**
+     * @var int
+     */
+    protected $size;
+
+    public function __construct(int $size, array $items = [])
+    {
+        $this->size = $size;
+        $this->items = $items;
+    }
+
+    /**
+     * @param mixed $item
+     *
+     * @return self
+     */
+    public function add($item)
+    {
+        $this->items[] = $item;
+
+        if (count($this->items) > $this->size) {
+            array_shift($this->items);
+        }
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return $this->items;
+    }
+
+    /**
+     * Clear the queue.
+     */
+    public function clear(): self
+    {
+        $this->items = [];
+
+        return $this;
+    }
+
+}

--- a/src/Support/EvictingQueue.php
+++ b/src/Support/EvictingQueue.php
@@ -53,5 +53,4 @@ class EvictingQueue
 
         return $this;
     }
-
 }

--- a/tests/BreadcrumbsTest.php
+++ b/tests/BreadcrumbsTest.php
@@ -8,7 +8,6 @@ use stdClass;
 
 class BreadcrumbsTest extends TestCase
 {
-
     /** @test */
     public function can_add_breadcrumbs()
     {

--- a/tests/BreadcrumbsTest.php
+++ b/tests/BreadcrumbsTest.php
@@ -78,6 +78,8 @@ class BreadcrumbsTest extends TestCase
                     'string' => 'hello',
                     'integer' => 3,
                     'float' => 3.5,
+                    'object' => '[DEPTH]',
+                    'array' => '[DEPTH]',
                 ],
                 'category' => 'custom',
                 'timestamp' => 123538954,

--- a/tests/BreadcrumbsTest.php
+++ b/tests/BreadcrumbsTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Honeybadger\Tests;
+
+use Honeybadger\Breadcrumbs;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class BreadcrumbsTest extends TestCase
+{
+
+    /** @test */
+    public function can_add_breadcrumbs()
+    {
+        $breadcrumbs = new Breadcrumbs(3);
+
+        $item = [
+            'message' => 'Database query',
+            'metadata' => [
+                'query' => 'SELECT things',
+            ],
+            'category' => 'query',
+            'timestamp' => time(),
+        ];
+        $breadcrumbs->add($item);
+
+        $items = $breadcrumbs->toArray();
+
+        $this->assertEquals([$item], $items);
+    }
+
+    /** @test */
+    public function limits_the_length_of_breadcrumbs()
+    {
+        $size = rand(1, 3);
+        $breadcrumbs = new Breadcrumbs($size);
+        $added = [];
+        foreach (range(0, 5) as $i) {
+            $item = ['message' => "$i", 'metadata' => []];
+            $added[] = $item;
+            $breadcrumbs->add($item);
+        }
+
+        $items = $breadcrumbs->toArray();
+        $this->assertCount($size, $items);
+
+        $expected = array_slice($added, 6 - $size);
+
+        foreach ($items as $key => $item) {
+            $this->assertEquals($expected[$key]['message'], $item['message']);
+            $this->assertEquals($expected[$key]['metadata'], $item['metadata']);
+        }
+    }
+
+    /** @test */
+    public function removes_nested_and_nonprimitive_items_in_metadata()
+    {
+        $breadcrumbs = new Breadcrumbs(3);
+
+        $item = [
+            'message' => 'A thing',
+            'metadata' => [
+                'object' => new stdClass(),
+                'array' => ['a' => 'b'],
+                'string' => 'hello',
+                'integer' => 3,
+                'float' => 3.5,
+            ],
+            'timestamp' => 123538954,
+        ];
+        $breadcrumbs->add($item);
+
+        $items = $breadcrumbs->toArray();
+
+        $this->assertEquals([
+            [
+                'message' => 'A thing',
+                'metadata' => [
+                    'string' => 'hello',
+                    'integer' => 3,
+                    'float' => 3.5,
+                ],
+                'category' => 'custom',
+                'timestamp' => 123538954,
+            ],
+        ], $items);
+    }
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -48,8 +48,10 @@ class ConfigTest extends TestCase
             'vendor_paths' => [
                 'vendor\/.*',
             ],
-            'breadcrumbs_enabled' => true,
-            'max_breadcrumbs' => 40,
+            'breadcrumbs' => [
+                'enabled' => true,
+                'keep' => 40,
+            ],
         ], $config);
     }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -48,6 +48,8 @@ class ConfigTest extends TestCase
             'vendor_paths' => [
                 'vendor\/.*',
             ],
+            'breadcrumbs_enabled' => true,
+            'max_breadcrumbs' => 40,
         ], $config);
     }
 }

--- a/tests/HoneybadgerTest.php
+++ b/tests/HoneybadgerTest.php
@@ -746,14 +746,15 @@ class HoneybadgerTest extends TestCase
 
         $notification = $client->requestBody();
 
-        $this->assertCount(1, $notification['breadcrumbs']);
-        $this->assertEquals('Honeybadger Notice', $notification['breadcrumbs'][0]['message']);
-        $this->assertEquals('notice', $notification['breadcrumbs'][0]['category']);
-        $this->assertIsInt($notification['breadcrumbs'][0]['timestamp']);
+        $this->assertTrue($notification['breadcrumbs']['enabled']);
+        $this->assertCount(1, $notification['breadcrumbs']['trail']);
+        $this->assertEquals('Honeybadger Notice', $notification['breadcrumbs']['trail'][0]['message']);
+        $this->assertEquals('notice', $notification['breadcrumbs']['trail'][0]['category']);
+        $this->assertIsInt($notification['breadcrumbs']['trail'][0]['timestamp']);
         $this->assertEquals([
             'message' => 'Test exception',
             'name' => Exception::class,
-        ], $notification['breadcrumbs'][0]['metadata']);
+        ], $notification['breadcrumbs']['trail'][0]['metadata']);
     }
 
     /** @test */
@@ -780,20 +781,21 @@ class HoneybadgerTest extends TestCase
 
         $notification = $client->requestBody();
 
-        $this->assertCount(2, $notification['breadcrumbs']);
+        $this->assertTrue($notification['breadcrumbs']['enabled']);
+        $this->assertCount(2, $notification['breadcrumbs']['trail']);
 
-        $this->assertEquals('A thing', $notification['breadcrumbs'][0]['message']);
-        $this->assertEquals('render', $notification['breadcrumbs'][0]['category']);
-        $this->assertEquals($eventTime, $notification['breadcrumbs'][0]['timestamp']);
-        $this->assertEquals(['some' => 'data'], $notification['breadcrumbs'][0]['metadata']);
+        $this->assertEquals('A thing', $notification['breadcrumbs']['trail'][0]['message']);
+        $this->assertEquals('render', $notification['breadcrumbs']['trail'][0]['category']);
+        $this->assertEquals($eventTime, $notification['breadcrumbs']['trail'][0]['timestamp']);
+        $this->assertEquals(['some' => 'data'], $notification['breadcrumbs']['trail'][0]['metadata']);
 
-        $this->assertEquals('Honeybadger Notice', $notification['breadcrumbs'][1]['message']);
-        $this->assertEquals('notice', $notification['breadcrumbs'][1]['category']);
-        $this->assertIsInt($notification['breadcrumbs'][1]['timestamp']);
+        $this->assertEquals('Honeybadger Notice', $notification['breadcrumbs']['trail'][1]['message']);
+        $this->assertEquals('notice', $notification['breadcrumbs']['trail'][1]['category']);
+        $this->assertIsInt($notification['breadcrumbs']['trail'][1]['timestamp']);
         $this->assertEquals([
             'message' => 'Test exception',
             'name' => Exception::class,
-        ], $notification['breadcrumbs'][1]['metadata']);
+        ], $notification['breadcrumbs']['trail'][1]['metadata']);
     }
 
     /** @test */
@@ -817,11 +819,8 @@ class HoneybadgerTest extends TestCase
 
         $notification = $client->requestBody();
 
-        $this->assertEquals('HomeController', $notification['request']['component']);
-        $this->assertEquals('index', $notification['request']['action']);
-        $this->assertArrayNotHasKey('component', $notification['request']['context']);
-        $this->assertArrayNotHasKey('action', $notification['request']['context']);
         $this->assertIsArray($notification['breadcrumbs']);
-        $this->assertCount(0, $notification['breadcrumbs']);
+        $this->assertFalse($notification['breadcrumbs']['enabled']);
+        $this->assertCount(0, $notification['breadcrumbs']['trail']);
     }
 }

--- a/tests/HoneybadgerTest.php
+++ b/tests/HoneybadgerTest.php
@@ -811,7 +811,9 @@ class HoneybadgerTest extends TestCase
                 'exception' => false,
                 'error' => false,
             ],
-            'breadcrumbs_enabled' => false,
+            'breadcrumbs' => [
+                'enabled' => false,
+            ],
         ], $client->make());
         $badger->setComponent('HomeController')
             ->setAction('index')

--- a/tests/HoneybadgerTest.php
+++ b/tests/HoneybadgerTest.php
@@ -750,7 +750,7 @@ class HoneybadgerTest extends TestCase
         $this->assertCount(1, $notification['breadcrumbs']['trail']);
         $this->assertEquals('Honeybadger Notice', $notification['breadcrumbs']['trail'][0]['message']);
         $this->assertEquals('notice', $notification['breadcrumbs']['trail'][0]['category']);
-        $this->assertIsInt($notification['breadcrumbs']['trail'][0]['timestamp']);
+        $this->assertStringStartsWith(substr(date('c'), 0, 17), $notification['breadcrumbs']['trail'][0]['timestamp']);
         $this->assertEquals([
             'message' => 'Test exception',
             'name' => Exception::class,
@@ -773,7 +773,7 @@ class HoneybadgerTest extends TestCase
         ], $client->make());
 
         sleep(1);
-        $eventTime = time();
+        $eventTime = date('c');
         $badger->addBreadcrumb('A thing', ['some' => 'data'], 'render')
             ->setComponent('HomeController')
             ->setAction('index')
@@ -791,7 +791,7 @@ class HoneybadgerTest extends TestCase
 
         $this->assertEquals('Honeybadger Notice', $notification['breadcrumbs']['trail'][1]['message']);
         $this->assertEquals('notice', $notification['breadcrumbs']['trail'][1]['category']);
-        $this->assertIsInt($notification['breadcrumbs']['trail'][1]['timestamp']);
+        $this->assertStringStartsWith(substr(date('c'), 0, 17), $notification['breadcrumbs']['trail'][1]['timestamp']);
         $this->assertEquals([
             'message' => 'Test exception',
             'name' => Exception::class,

--- a/tests/HoneybadgerTest.php
+++ b/tests/HoneybadgerTest.php
@@ -750,7 +750,7 @@ class HoneybadgerTest extends TestCase
         $this->assertCount(1, $notification['breadcrumbs']['trail']);
         $this->assertEquals('Honeybadger Notice', $notification['breadcrumbs']['trail'][0]['message']);
         $this->assertEquals('notice', $notification['breadcrumbs']['trail'][0]['category']);
-        $this->assertStringStartsWith(substr(date('c'), 0, 17), $notification['breadcrumbs']['trail'][0]['timestamp']);
+        $this->assertInstanceOf(\DateTime::class, date_create($notification['breadcrumbs']['trail'][0]['timestamp']));
         $this->assertEquals([
             'message' => 'Test exception',
             'name' => Exception::class,
@@ -791,7 +791,7 @@ class HoneybadgerTest extends TestCase
 
         $this->assertEquals('Honeybadger Notice', $notification['breadcrumbs']['trail'][1]['message']);
         $this->assertEquals('notice', $notification['breadcrumbs']['trail'][1]['category']);
-        $this->assertStringStartsWith(substr(date('c'), 0, 17), $notification['breadcrumbs']['trail'][1]['timestamp']);
+        $this->assertInstanceOf(\DateTime::class, date_create($notification['breadcrumbs']['trail'][1]['timestamp']));
         $this->assertEquals([
             'message' => 'Test exception',
             'name' => Exception::class,


### PR DESCRIPTION
## Status
**READY**

## Description
Implementation of #140

Went with config keys of `breadcrumbs.enabled` and `breadcrumbs.keep`.

Also auto-add breadcrumb for `notice` events, in line with other libraries.

## Related PRs
- Docs: (coming soon)