### PR TITLE
Update notifier name

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -25,7 +25,7 @@ class Config extends Repository
         return array_merge([
             'api_key' => null,
             'notifier' => [
-                'name' => 'Honeybadger PHP',
+                'name' => 'honeybadger-php',
                 'url' => 'https://github.com/honeybadger-io/honeybadger-php',
                 'version' => Honeybadger::VERSION,
             ],

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -19,7 +19,7 @@ class Honeybadger implements Reporter
     /**
      * SDK Version.
      */
-    const VERSION = '2.7.0';
+    const VERSION = '2.8.0';
 
     /**
      * Honeybadger API URL.

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -19,7 +19,7 @@ class ConfigTest extends TestCase
         $this->assertEquals([
             'api_key' => '1234',
             'notifier' => [
-                'name' => 'Honeybadger PHP',
+                'name' => 'honeybadger-php',
                 'url' => 'https://github.com/honeybadger-io/honeybadger-php',
                 'version' => Honeybadger::VERSION,
             ],

--- a/tests/HoneyBadgerTest.php
+++ b/tests/HoneyBadgerTest.php
@@ -34,7 +34,7 @@ class HoneyBadgerTest extends TestCase
         $notification = $client->requestBody();
 
         $this->assertEquals([
-            'name' => 'Honeybadger PHP',
+            'name' => 'honeybadger-php',
             'version' => Honeybadger::VERSION,
             'url' => 'https://github.com/honeybadger-io/honeybadger-php',
         ], $notification['notifier']);


### PR DESCRIPTION
This changes `notice['notifier']['name']` to match the format of our
other client libraries (honeybadger-ruby, honeybadger-elixir, etc.).

Also bumps the version for local testing displaying breadcrumbs in
Honeybadger UI.