### PR TITLE
Capture the previous exception in generic ServiceException

### DIFF
--- a/src/Exceptions/ServiceException.php
+++ b/src/Exceptions/ServiceException.php
@@ -38,8 +38,16 @@ class ServiceException extends Exception
         return new static('There was an error on our end.');
     }
 
+    public static function unexpectedResponseCode(int $code): self
+    {
+        return new static("Unexpected HTTP response code: $code");
+    }
+
     public static function generic(\Throwable $e = null): self
     {
-        return new static('There was an error sending the payload to Honeybadger: '.$e->getMessage(), 0, $e);
+        $message = $e
+            ? 'There was an error sending the payload to Honeybadger: '.$e->getMessage()
+            : 'There was an error sending the payload to Honeybadger.';
+        return new static($message, 0, $e);
     }
 }

--- a/src/Exceptions/ServiceException.php
+++ b/src/Exceptions/ServiceException.php
@@ -48,6 +48,7 @@ class ServiceException extends Exception
         $message = $e
             ? 'There was an error sending the payload to Honeybadger: '.$e->getMessage()
             : 'There was an error sending the payload to Honeybadger.';
+
         return new static($message, 0, $e);
     }
 }

--- a/src/Exceptions/ServiceException.php
+++ b/src/Exceptions/ServiceException.php
@@ -38,11 +38,8 @@ class ServiceException extends Exception
         return new static('There was an error on our end.');
     }
 
-    /**
-     * @return \Honeybadger\Exceptions\ServiceException
-     */
-    public static function generic(): self
+    public static function generic(\Throwable $e = null): self
     {
-        return new static('There was an error sending the payload to Honeybadger.');
+        return new static('There was an error sending the payload to Honeybadger: '.$e->getMessage(), 0, $e);
     }
 }

--- a/src/Exceptions/ServiceExceptionFactory.php
+++ b/src/Exceptions/ServiceExceptionFactory.php
@@ -44,6 +44,6 @@ class ServiceExceptionFactory
             return ServiceException::serverError();
         }
 
-        return ServiceException::generic();
+        return ServiceException::unexpectedResponseCode($this->response->getStatusCode());
     }
 }

--- a/tests/ServiceExceptionTest.php
+++ b/tests/ServiceExceptionTest.php
@@ -51,9 +51,9 @@ class ServiceExceptionTest extends TestCase
     }
 
     /** @test */
-    public function it_throws_a_generic_exception_if_all_else_fails()
+    public function it_throws_an_unexpected_response_code_exception_if_all_else_fails()
     {
-        $this->expectExceptionObject(ServiceException::generic());
+        $this->expectExceptionObject(ServiceException::unexpectedResponseCode(Response::HTTP_I_AM_A_TEAPOT));
 
         $response = new GuzzleResponse(Response::HTTP_I_AM_A_TEAPOT);
 


### PR DESCRIPTION
## Status
**READY**

## Description
Currently the `ServiceException::generic()` is thrown in a couple of places where an unknown exception occurred while sending the payload, and it discards the exception that was originally thrown, losing any context. See https://github.com/honeybadger-io/honeybadger-php/blob/95ea3d9702ca83f0784e2ba7db8d66ef087383c4/src/HoneybadgerClient.php#L45-L47. This fixes that.

Additionally, this PR adds an `unexpectedResponseCode()` exception factory, to be used instead of `generic` when the response code is unexpected, since we do know what the problem is.