### PR TITLE
Allow spatie/regex version 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.3|^7.0.1",
         "monolog/monolog": "^2.0",
-        "spatie/regex": "^1.4",
+        "spatie/regex": "^1.4|^2.0",
         "symfony/http-foundation": ">=3.3|^4.1"
     },
     "require-dev": {


### PR DESCRIPTION
Having spatie/regex ^2.0 for my current project I get errors when I try to install honeybadger-laravel because of version 2.0 of spatie/regex is not allowed in this composer.json.

Thanks for merging!
