### PR TITLE
Handle silenced errors properly on PHP 8

### DIFF
--- a/src/Handlers/ErrorHandler.php
+++ b/src/Handlers/ErrorHandler.php
@@ -13,6 +13,18 @@ class ErrorHandler extends Handler implements HandlerContract
     protected $previousHandler;
 
     /**
+     * The fatal error types that cannot be silenced using the @ operator in PHP 8+.
+     */
+    private const PHP8_UNSILENCEABLE_ERRORS = [
+        E_ERROR,
+        E_PARSE,
+        E_CORE_ERROR,
+        E_COMPILE_ERROR,
+        E_USER_ERROR,
+        E_RECOVERABLE_ERROR
+    ];
+
+    /**
      * @return void
      */
     public function register(): void
@@ -20,27 +32,37 @@ class ErrorHandler extends Handler implements HandlerContract
         $this->previousHandler = set_error_handler([$this, 'handle']);
     }
 
-    /**
-     * @param  int  $code
-     * @param  string  $error
-     * @param  string  $file
-     * @param  int  $line
-     * @return mixed
-     *
-     * @throws \Honeyhadger\Exceptions\ServiceException
-     */
-    public function handle($code, $error, $file = null, $line = null)
+    public function handle(int $level, string $error, string $file = null, int $line = null): bool
     {
-        if (error_reporting() === 0) {
+        // When the @ operator is used, it temporarily changes `error_reporting()`'s return value
+        // to reflect what error types should be reported. This means we should get 0 (no errors).
+        $errorReportingLevel = error_reporting();
+        $isSilenced = ($errorReportingLevel == 0);
+
+        if (PHP_MAJOR_VERSION >= 8) {
+            // In PHP 8+, some errors are unsilenceable, so we should respect that.
+            if (in_array($level, self::PHP8_UNSILENCEABLE_ERRORS)) {
+                $isSilenced = false;
+            } else {
+                // If an error is silenced, `error_reporting()` won't return 0,
+                // but rather a bitmask of the unsilenceable errors.
+                $unsilenceableErrorsBitmask = array_reduce(self::PHP8_UNSILENCEABLE_ERRORS, function ($bitMask, $errLevel) {
+                    return $bitMask | $errLevel;
+                });
+                $isSilenced = $errorReportingLevel === $unsilenceableErrorsBitmask;
+            }
+        }
+
+        if ($isSilenced) {
             return false;
         }
 
         $this->honeybadger->notify(
-            new ErrorException($error, 0, $code, $file, $line)
+            new ErrorException($error, 0, $level, $file, $line)
         );
 
         if (is_callable($this->previousHandler)) {
-            call_user_func($this->previousHandler, $code, $error, $file, $line);
+            call_user_func($this->previousHandler, $level, $error, $file, $line);
         }
     }
 }

--- a/src/Handlers/ErrorHandler.php
+++ b/src/Handlers/ErrorHandler.php
@@ -32,7 +32,7 @@ class ErrorHandler extends Handler implements HandlerContract
         $this->previousHandler = set_error_handler([$this, 'handle']);
     }
 
-    public function handle(int $level, string $error, string $file = null, int $line = null): bool
+    public function handle(int $level, string $error, string $file = null, int $line = null)
     {
         // When the @ operator is used, it temporarily changes `error_reporting()`'s return value
         // to reflect what error types should be reported. This means we should get 0 (no errors).
@@ -46,8 +46,9 @@ class ErrorHandler extends Handler implements HandlerContract
             } else {
                 // If an error is silenced, `error_reporting()` won't return 0,
                 // but rather a bitmask of the unsilenceable errors.
-                $unsilenceableErrorsBitmask = array_reduce(self::PHP8_UNSILENCEABLE_ERRORS, function ($bitMask, $errLevel) {
-                    return $bitMask | $errLevel;
+                $unsilenceableErrorsBitmask = array_reduce(
+                    self::PHP8_UNSILENCEABLE_ERRORS, function ($bitMask, $errLevel) {
+                        return $bitMask | $errLevel;
                 });
                 $isSilenced = $errorReportingLevel === $unsilenceableErrorsBitmask;
             }

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -8,11 +8,12 @@ use Honeybadger\Handlers\ExceptionHandler;
 use Honeybadger\Honeybadger;
 use Honeybadger\Tests\Fixtures\HandlerFixture;
 use PHPUnit\Framework\TestCase;
+use Throwable;
 
 class HandlerTest extends TestCase
 {
     /** @test */
-    public function exception_handler_get_set()
+    public function exception_handler_gets_set()
     {
         $handlerFixture = new HandlerFixture;
         set_exception_handler([$handlerFixture, 'exceptionHandler']);
@@ -34,7 +35,7 @@ class HandlerTest extends TestCase
     }
 
     /** @test */
-    public function error_handler_get_set()
+    public function error_handler_gets_set()
     {
         // cache previous error handler
         $previousHandler = set_error_handler(null);
@@ -60,7 +61,54 @@ class HandlerTest extends TestCase
             null,
         ], $handlerFixture->args);
 
-        // Restore phpunithandler
+        // Restore PHPUnit's handler
+        set_error_handler($previousHandler);
+    }
+
+    /** @test */
+    public function ignores_silenced_errors_properly()
+    {
+        // Cache previous error handler
+        $previousHandler = set_error_handler(null);
+
+        $mock = $this->createMock(Honeybadger::class);
+        $mock->expects($this->never())->method('notify');
+
+        $handler = new ErrorHandler($mock);
+        $handler->register();
+
+        $x = [];
+        @$x[3]++;
+
+        // Restore PHPUnit's handler
+        set_error_handler($previousHandler);
+    }
+
+    /** @test */
+    public function does_not_ignore_php8_unsilenceable_errors()
+    {
+        if (PHP_MAJOR_VERSION < 8) {
+            $this->markTestSkipped("All errors can be silenced on PHP < 8");
+        }
+
+        // Cache previous error handler
+        $previousHandler = set_error_handler(null);
+
+        $mock = $this->createMock(Honeybadger::class);
+        $mock->expects($this->once())->method('notify')
+            ->willReturnCallback(function (Throwable $exception) {
+                $this->assertInstanceOf(\ErrorException::class, $exception);
+                $this->assertEquals("A fatal error which can not be silenced", $exception->getMessage());
+
+                return [];
+            });
+
+        $handler = new ErrorHandler($mock);
+        $handler->register();
+
+        @trigger_error("A fatal error which can not be silenced", E_USER_ERROR);
+
+        // Restore PHPUnit's handler
         set_error_handler($previousHandler);
     }
 }


### PR DESCRIPTION
## Status
**READY**

## Description
PHP 8 made some changes to the behaviour of the error-silencing operator (`@`) and classification of errors. This PR handles them properly.

Closes #146