### PR TITLE
Set default client timeout

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -49,7 +49,7 @@ class Config extends Repository
                 'error' => true,
             ],
             'client' => [
-                'timeout' => 0,
+                'timeout' => 15,
                 'proxy' => [],
                 'verify' => true,
             ],

--- a/src/Exceptions/ServiceExceptionFactory.php
+++ b/src/Exceptions/ServiceExceptionFactory.php
@@ -2,7 +2,6 @@
 
 namespace Honeybadger\Exceptions;
 
-use Exception;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -39,7 +39,7 @@ class ConfigTest extends TestCase
                 'error' => true,
             ],
             'client' => [
-                'timeout' => 0,
+                'timeout' => 15,
                 'proxy' => [],
                 'verify' => true,
             ],


### PR DESCRIPTION
This PR sets a default timeout of 15 seconds for Honeybadger API calls. Since this is PHP, these API calls will most likely be made within the lifetime of the web request. If Honeybagder for some reason is unreachable, without a timeout, this will go on until it hits PHP's max script execution time, crashing their app as a result.

Good read [here](https://medium.com/@masnun/always-use-a-timeout-for-http-requests-de4da538b9e3).