### PR TITLE
Monolog handler: Format exceptions properly

### DIFF
--- a/src/LogHandler.php
+++ b/src/LogHandler.php
@@ -35,7 +35,7 @@ class LogHandler extends AbstractProcessingHandler
         $this->honeybadger->rawNotification(function ($config) use ($record) {
             return [
                 'notifier' => array_merge($config['notifier'], ['name' => 'Honeybadger Log Handler']),
-                'error' => $this->getHoneybadgerErrorFromMonologRecord($record),
+                'error' => $this->getHoneybadgerErrorFromMonologRecord($record, $config),
                 'request' => [
                     'context' => $this->getHoneybadgerContextFromMonologRecord($record),
                 ],
@@ -55,7 +55,7 @@ class LogHandler extends AbstractProcessingHandler
         return new LineFormatter('[%datetime%] %channel%.%level_name%: %message%');
     }
 
-    protected function getHoneybadgerErrorFromMonologRecord(array $record): array
+    protected function getHoneybadgerErrorFromMonologRecord(array $record, $config): array
     {
         $error = [
             'tags' => [
@@ -68,6 +68,7 @@ class LogHandler extends AbstractProcessingHandler
         if ($e instanceof \Throwable) {
             $error['class'] = get_class($e);
             $error['message'] = $e->getMessage();
+            $error['backtrace'] = (new BacktraceFactory($e, $config))->trace();
         } else {
             $error['class'] = "{$record['level_name']} Log";
             $error['message'] = $record['message'];
@@ -90,7 +91,6 @@ class LogHandler extends AbstractProcessingHandler
                 'code' => $e->getCode(),
                 'file' => $e->getFile(),
                 'line' => $e->getLine(),
-                'trace' => $e->getTrace(),
             ];
         }
 

--- a/src/LogHandler.php
+++ b/src/LogHandler.php
@@ -2,7 +2,6 @@
 
 namespace Honeybadger;
 
-use DateTime;
 use Honeybadger\Contracts\Reporter;
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Formatter\LineFormatter;

--- a/src/LogHandler.php
+++ b/src/LogHandler.php
@@ -62,7 +62,7 @@ class LogHandler extends AbstractProcessingHandler
                 'log',
                 sprintf('%s.%s', $record['channel'], $record['level_name']),
             ],
-            'fingerprint' => md5($record['message']),
+            'fingerprint' => md5($record['level_name'].$record['message']),
         ];
         $e = $record['context']['exception'] ?? null;
         if ($e instanceof \Throwable) {

--- a/tests/LogHandlerTest.php
+++ b/tests/LogHandlerTest.php
@@ -2,7 +2,6 @@
 
 namespace Honeybadger\Tests;
 
-use DateTime;
 use Honeybadger\Contracts\Reporter;
 use Honeybadger\Honeybadger;
 use Honeybadger\LogHandler;
@@ -60,7 +59,7 @@ class LogHandlerTest extends TestCase
                     'some' => 'data',
                 ],
             ],
-        ], array_only($reporter->notification, ['notifier', 'request',]));
+        ], array_only($reporter->notification, ['notifier', 'request']));
 
         $this->assertArrayHasKey('time', $reporter->notification['server']);
         $this->assertEquals('production', $reporter->notification['server']['environment_name']);
@@ -121,7 +120,7 @@ class LogHandlerTest extends TestCase
                     ],
                 ],
             ],
-        ], array_only($reporter->notification, ['notifier', 'request',]));
+        ], array_only($reporter->notification, ['notifier', 'request']));
 
         $this->assertArrayHasKey('time', $reporter->notification['server']);
         $this->assertEquals('production', $reporter->notification['server']['environment_name']);

--- a/tests/LogHandlerTest.php
+++ b/tests/LogHandlerTest.php
@@ -2,6 +2,8 @@
 
 namespace Honeybadger\Tests;
 
+use Honeybadger\BacktraceFactory;
+use Honeybadger\Config;
 use Honeybadger\Contracts\Reporter;
 use Honeybadger\Honeybadger;
 use Honeybadger\LogHandler;
@@ -116,7 +118,6 @@ class LogHandlerTest extends TestCase
                         'code' => $e->getCode(),
                         'file' => $e->getFile(),
                         'line' => $e->getLine(),
-                        'trace' => $e->getTrace(),
                     ],
                 ],
             ],
@@ -128,11 +129,12 @@ class LogHandlerTest extends TestCase
         $this->assertEquals([
             'class' => get_class($e),
             'message' => $e->getMessage(),
+            'backtrace' => (new BacktraceFactory($e, new Config([])))->trace(),
             'tags' => [
                 'log',
                 'test-logger.ERROR',
             ],
-        ], array_only($reporter->notification['error'], ['class', 'tags', 'message']));
+        ], array_except($reporter->notification['error'], ['fingerprint']));
 
         $this->assertFalse(empty($reporter->notification['error']['fingerprint']));
     }

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -7,7 +7,6 @@ function array_only($array, $keys)
     return array_intersect_key($array, array_flip((array) $keys));
 }
 
-
 function array_except($array, $keys)
 {
     return array_diff_key($array, array_flip((array) $keys));

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -6,3 +6,9 @@ function array_only($array, $keys)
 {
     return array_intersect_key($array, array_flip((array) $keys));
 }
+
+
+function array_except($array, $keys)
+{
+    return array_diff_key($array, array_flip((array) $keys));
+}


### PR DESCRIPTION
This PR improves the formatting of ERROR logs set via the Monolog log handler, so they look more like exceptions caught via the normal agent. Also unwraps the monolog `context` parameter into Honeybadger context.

This will make it more useful especially in framework integrations like https://github.com/honeybadger-io/honeybadger-laravel/pull/17 — you can use Honeybadger as a logging channel for error logs and still get the same benefits as using it to catch exceptions.
