### PR TITLE
Filter query params from request URL

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -4,3 +4,4 @@ disabled:
   - laravel_braces
   - single_class_element_per_statement
   - laravel_phpdoc_alignment
+  - laravel_phpdoc_separation

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -3,3 +3,4 @@ preset: laravel
 disabled:
   - laravel_braces
   - single_class_element_per_statement
+  - laravel_phpdoc_alignment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Filter configured query parameters from the URL ([#154](https://github.com/honeybadger-io/honeybadger-php/pull/154))
 
 ## [2.11.0] - 2021-06-29
 ### Added

--- a/src/Concerns/FiltersData.php
+++ b/src/Concerns/FiltersData.php
@@ -37,7 +37,7 @@ trait FiltersData
                 return $this->filter($value);
             }
 
-            if (in_array($key, $this->keysToFilter)) {
+            if ($value !== '' && in_array($key, $this->keysToFilter)) {
                 return '[FILTERED]';
             }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -4,7 +4,6 @@ namespace Honeybadger;
 
 use Honeybadger\Concerns\FiltersData;
 use Symfony\Component\HttpFoundation\Request as FoundationRequest;
-use function GuzzleHttp\Psr7\parse_query;
 
 class Request
 {
@@ -38,7 +37,7 @@ class Request
             ? $this->request->getUri()
             : '';
 
-        if (!$url) {
+        if (! $url) {
             return $url;
         }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -46,7 +46,8 @@ class Request
         $queryString = parse_url($url, PHP_URL_QUERY);
         $filteredQueryParams = array_map(function ($keyAndValue) {
             $parts = explode('=', $keyAndValue);
-            if (isset($parts[1]) && in_array($parts[0], $this->keysToFilter)) {
+            if (isset($parts[1]) && $parts[1] !== ''
+                && in_array($parts[0], $this->keysToFilter)) {
                 return "{$parts[0]}=[FILTERED]";
             }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -132,6 +132,7 @@ class RequestTest extends TestCase
 
         $request->overrideGlobals();
 
+        $filteredRequest = (new Request($request))->filterKeys(['query2']);
         $this->assertEquals([
             'method' => 'GET',
             'query' => [
@@ -139,7 +140,8 @@ class RequestTest extends TestCase
                 'query2' => '[FILTERED]',
             ],
             'data' => [],
-        ], (new Request($request))->filterKeys(['query2'])->params());
+        ], $filteredRequest->params());
+        $this->assertEquals('http://honeybadger.dev/test?query1=foo&query2=[FILTERED]', $filteredRequest->url());
     }
 
     /** @test */

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -152,7 +152,7 @@ class RequestTest extends TestCase
                 'query1' => 'foo',
                 'query2' => '[FILTERED]',
             ],
-            'http://honeybadger.dev/test?query1=foo&query2=[FILTERED]'
+            'http://honeybadger.dev/test?query1=foo&query2=[FILTERED]',
         ];
         yield 'with empty value' => [
             'http://honeybadger.dev/test?query1=foo&query2=',
@@ -160,7 +160,7 @@ class RequestTest extends TestCase
                 'query1' => 'foo',
                 'query2' => '',
             ],
-            'http://honeybadger.dev/test?query1=foo&query2='
+            'http://honeybadger.dev/test?query1=foo&query2=',
         ];
     }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -122,11 +122,14 @@ class RequestTest extends TestCase
         );
     }
 
-    /** @test */
-    public function it_filters_query_params()
+    /**
+     * @dataProvider queryParamUrls
+     * @test
+     */
+    public function it_filters_query_params($url, $filteredQueryParams, $filteredUrl)
     {
         $request = FoundationRequest::create(
-            'http://honeybadger.dev/test?query1=foo&query2=bar',
+            $url,
             'GET'
         );
 
@@ -135,13 +138,30 @@ class RequestTest extends TestCase
         $filteredRequest = (new Request($request))->filterKeys(['query2']);
         $this->assertEquals([
             'method' => 'GET',
-            'query' => [
+            'query' => $filteredQueryParams,
+            'data' => [],
+        ], $filteredRequest->params());
+        $this->assertEquals($filteredUrl, $filteredRequest->url());
+    }
+
+    public function queryParamUrls()
+    {
+        yield 'with value' => [
+            'http://honeybadger.dev/test?query1=foo&query2=bar',
+            [
                 'query1' => 'foo',
                 'query2' => '[FILTERED]',
             ],
-            'data' => [],
-        ], $filteredRequest->params());
-        $this->assertEquals('http://honeybadger.dev/test?query1=foo&query2=[FILTERED]', $filteredRequest->url());
+            'http://honeybadger.dev/test?query1=foo&query2=[FILTERED]'
+        ];
+        yield 'with empty value' => [
+            'http://honeybadger.dev/test?query1=foo&query2=',
+            [
+                'query1' => 'foo',
+                'query2' => '',
+            ],
+            'http://honeybadger.dev/test?query1=foo&query2='
+        ];
     }
 
     /** @test */


### PR DESCRIPTION
Fixes #153

I also changed the behaviour of the filter, so it only filters params that have a value. For example, if the request was `?password=mypassword`, you'll get `?password=[FILTERED]`, but if it was `?password=` (no value provided), you'll get it as-is. Might help with debugging problems—the customer can now see that a parameter was not sent.