### PR TITLE
Special handling of errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Format errors differently from exceptions ([#160](https://github.com/honeybadger-io/honeybadger-php/pull/160))
+- `capture_deprecations` option to disable capturing deprecation warnings ([#160](https://github.com/honeybadger-io/honeybadger-php/pull/160))
 
 ## [2.11.3] - 2022-02-07
 ### Fixed

--- a/src/BacktraceFactory.php
+++ b/src/BacktraceFactory.php
@@ -80,7 +80,7 @@ class BacktraceFactory
             // For errors (ie not exceptions), the trace wrongly starts from
             // when we created the wrapping ErrorException class.
             // So we unwind it to the actual error location
-            while (strpos($backtrace[0]['class'], 'Honeybadger\\') !== false) {
+            while (strpos($backtrace[0]['class'] ?? '', 'Honeybadger\\') !== false) {
                 array_shift($backtrace);
             }
         } else {

--- a/src/BacktraceFactory.php
+++ b/src/BacktraceFactory.php
@@ -2,6 +2,7 @@
 
 namespace Honeybadger;
 
+use ErrorException;
 use ReflectionClass;
 use ReflectionException;
 use Spatie\Regex\Regex;
@@ -75,10 +76,19 @@ class BacktraceFactory
      */
     private function offsetForThrownException(array $backtrace): array
     {
-        $backtrace[0] = array_merge($backtrace[0] ?? [], [
-            'line' => $this->exception->getLine(),
-            'file' => $this->exception->getFile(),
-        ]);
+        if ($this->exception instanceof ErrorException) {
+            // For errors (ie not exceptions), the trace wrongly starts from
+            // when we created the wrapping ErrorException class.
+            // So we unwind it to the actual error location
+            while (strpos($backtrace[0]['class'], 'Honeybadger\\') !== false) {
+                array_shift($backtrace);
+            }
+        } else {
+            $backtrace[0] = array_merge($backtrace[0] ?? [], [
+                'line' => $this->exception->getLine(),
+                'file' => $this->exception->getFile(),
+            ]);
+        }
 
         return $backtrace;
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -55,6 +55,7 @@ class Config extends Repository
                 'verify' => true,
             ],
             'excluded_exceptions' => [],
+            'capture_deprecations' => false,
             'vendor_paths' => [
                 'vendor\/.*',
             ],

--- a/src/ExceptionNotification.php
+++ b/src/ExceptionNotification.php
@@ -155,7 +155,7 @@ class ExceptionNotification
             $severityName = $this->friendlyErrorName($severity);
 
             return $severity == E_DEPRECATED || $severity == E_USER_DEPRECATED
-                ? "Deprecation Error ($severityName)"
+                ? "Deprecation Warning ($severityName)"
                 : "Error ($severityName)";
         }
 

--- a/src/Handlers/ErrorHandler.php
+++ b/src/Handlers/ErrorHandler.php
@@ -59,11 +59,16 @@ class ErrorHandler extends Handler implements HandlerContract
         }
 
         $this->honeybadger->notify(
-            new ErrorException($error, 0, $level, $file, $line)
+            $this->wrapError($error, $level, $file, $line)
         );
 
         if (is_callable($this->previousHandler)) {
             call_user_func($this->previousHandler, $level, $error, $file, $line);
         }
+    }
+
+    protected function wrapError(string $error, int $level, ?string $file, ?int $line): ErrorException
+    {
+        return new ErrorException($error, 0, $level, $file, $line);
     }
 }

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -2,6 +2,7 @@
 
 namespace Honeybadger;
 
+use ErrorException;
 use GuzzleHttp\Client;
 use Honeybadger\Concerns\Newable;
 use Honeybadger\Contracts\Reporter;
@@ -204,6 +205,12 @@ class Honeybadger implements Reporter
      */
     protected function shouldReport(Throwable $throwable): bool
     {
+        if ($throwable instanceof ErrorException
+            && in_array($throwable->getSeverity(), [E_DEPRECATED, E_USER_DEPRECATED])
+            && $this->config['capture_deprecations'] == false) {
+            return false;
+        }
+
         return ! $this->excludedException($throwable)
             && ! empty($this->config['api_key'])
             && $this->config['report_data'];

--- a/src/Request.php
+++ b/src/Request.php
@@ -53,7 +53,9 @@ class Request
             return $keyAndValue;
         }, explode('&', $queryString));
 
-        return str_replace($queryString || '', implode('&', $filteredQueryParams), $url);
+        return $queryString
+            ? str_replace($queryString, implode('&', $filteredQueryParams), $url)
+            : $url;
     }
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -53,7 +53,7 @@ class Request
             return $keyAndValue;
         }, explode('&', $queryString));
 
-        return str_replace($queryString, implode('&', $filteredQueryParams), $url);
+        return str_replace($queryString || '', implode('&', $filteredQueryParams), $url);
     }
 
     /**

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -45,6 +45,7 @@ class ConfigTest extends TestCase
                 'verify' => true,
             ],
             'excluded_exceptions' => [],
+            'capture_deprecations' => false,
             'report_data' => true,
             'vendor_paths' => [
                 'vendor\/.*',


### PR DESCRIPTION
PHP separates errors from exceptions, so we need to take that into account. Currently, we wrap errors in ErrorException`, but reporting them that way is misleading, since the stack trace points to where the exception was created.

This PR fixes the stack trace and also changes the reported "class" to report the original error code.

![image](https://user-images.githubusercontent.com/14361073/167026308-c5e2a8e0-7dec-4d64-9d93-7ecabf1ce515.png)

![image](https://user-images.githubusercontent.com/14361073/167027740-a6d6a563-5d48-43c5-96c9-9c4a2b6b3052.png)


Also added the `capture_deprecations` config flag to turn off reporting of deprecations.


