### PR TITLE
Log Handler: Ignore non-error logs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
     name: PHP ${{ matrix.php-versions }} Tests (${{ matrix.composer-flags }})
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- LogHandler: Check log level before writing the log [#168](https://github.com/honeybadger-io/honeybadger-php/pull/168)
 
 ## [2.14.0] - 2023-02-16
 - Monolog 3 support

--- a/src/LogHandler.php
+++ b/src/LogHandler.php
@@ -17,10 +17,10 @@ class LogHandler extends AbstractProcessingHandler
 
     /**
      * @param \Honeybadger\Contracts\Reporter $honeybadger
-     * @param int $level
+     * @param $level
      * @param bool $bubble
      */
-    public function __construct(Reporter $honeybadger, int $level = Logger::DEBUG, bool $bubble = true)
+    public function __construct(Reporter $honeybadger, $level = Logger::ERROR, bool $bubble = true)
     {
         parent::__construct($level, $bubble);
 
@@ -32,6 +32,10 @@ class LogHandler extends AbstractProcessingHandler
      */
     protected function write($record): void
     {
+        if (!$this->isHandling($record)) {
+            return;
+        }
+
         $this->honeybadger->rawNotification(function ($config) use ($record) {
             return [
                 'notifier' => array_merge($config['notifier'], ['name' => 'Honeybadger Log Handler']),


### PR DESCRIPTION
Part of the fix for https://github.com/honeybadger-io/honeybadger-laravel/issues/105

It turns out that setting the minimum log level isn't enough; the handler has to explicitly check that the record passes.

Related:
- https://github.com/honeybadger-io/docs/pull/326
- https://github.com/honeybadger-io/honeybadger-laravel/pull/106