### PR TITLE
fix(check-ins): do not allow check-ins with same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.17.1] - 2023-11-10
+### Fixed
+- Check-Ins: Do not allow check-ins with same names and project id
+- Check-Ins: Send empty string for optional values so that they will be updated when unset
+
 ## [2.17.0] - 2023-10-27
 ### Added
 - Check-Ins: Support for slug configuration within the package

--- a/src/Checkin.php
+++ b/src/Checkin.php
@@ -140,17 +140,21 @@ class Checkin
     {
         $result = [
             'name' => $this->name,
-            'slug' => $this->slug,
             'schedule_type' => $this->scheduleType,
-            'report_period' => $this->reportPeriod,
-            'grace_period' => $this->gracePeriod,
-            'cron_schedule' => $this->cronSchedule,
-            'cron_timezone' => $this->cronTimezone,
+            'slug' => $this->slug ?? '',
+            'grace_period' => $this->gracePeriod ?? '',
         ];
 
-        return array_filter($result, function ($value) {
-            return !is_null($value);
-        });
+        if ($this->scheduleType === 'simple') {
+            $result['report_period'] = $this->reportPeriod;
+        }
+
+        if ($this->scheduleType === 'cron') {
+            $result['cron_schedule'] = $this->cronSchedule;
+            $result['cron_timezone'] = $this->cronTimezone ?? '';
+        }
+
+        return $result;
     }
 
     /**
@@ -160,12 +164,12 @@ class Checkin
      */
     public function isInSync(Checkin $other): bool {
         return $this->name === $other->name
-            && $this->slug === $other->slug
+            && ($this->slug ?? '') === ($other->slug ?? '')
             && $this->projectId === $other->projectId
             && $this->scheduleType === $other->scheduleType
             && $this->reportPeriod === $other->reportPeriod
-            && $this->gracePeriod === $other->gracePeriod
+            && ($this->gracePeriod ?? '') === ($other->gracePeriod ?? '')
             && $this->cronSchedule === $other->cronSchedule
-            && $this->cronTimezone === $other->cronTimezone;
+            && ($this->cronTimezone ?? '') === ($other->cronTimezone ?? '');
     }
 }

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -20,7 +20,7 @@ class Honeybadger implements Reporter
     /**
      * SDK Version.
      */
-    const VERSION = '2.17.0';
+    const VERSION = '2.17.1';
 
     /**
      * Honeybadger API URL.

--- a/tests/CheckinsManagerTest.php
+++ b/tests/CheckinsManagerTest.php
@@ -14,6 +14,13 @@ use PHPUnit\Framework\TestCase;
 
 class CheckinsManagerTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Mockery::close();
+    }
+
+
     /** @test */
     public function throws_when_config_is_invalid()
     {
@@ -83,8 +90,10 @@ class CheckinsManagerTest extends TestCase
 
         $mock = Mockery::mock(CheckinsClient::class);
         $mock->shouldReceive('listForProject')
+            ->twice()
             ->andReturn([]);
         $mock->shouldReceive('create')
+            ->once()
             ->andReturn(new Checkin(array_merge(['id' => 'c1234'], $localCheckin)));
 
         $manager = new CheckinsManager($config, $mock);
@@ -117,8 +126,10 @@ class CheckinsManagerTest extends TestCase
 
         $mock = Mockery::mock(CheckinsClient::class, ['config' => $config]);
         $mock->shouldReceive('listForProject')
+            ->twice()
             ->andReturn($remoteCheckins);
         $mock->shouldReceive('update')
+            ->once()
             ->andReturn(new Checkin(array_merge(['id' => 'c1234'], $localCheckin)));
 
         $manager = new CheckinsManager($config, $mock);
@@ -129,6 +140,44 @@ class CheckinsManagerTest extends TestCase
 
         $newCheckin = $result[0];
         $this->assertEquals('c1234', $newCheckin->id);
+        $this->assertTrue($newCheckin->isInSync(new Checkin($localCheckin)));
+    }
+
+    /** @test */
+    public function unsets_checkins_optional_value() {
+        $checkinId = 'c1234';
+        $config = [
+            'personal_auth_token' => 'abcd'
+        ];
+        $localCheckin = [
+            'project_id' => 'p1234',
+            'name' => 'Test Checkin',
+            'schedule_type' => 'simple',
+            'report_period' => '1 day',
+        ];
+        $checkinsConfig = [$localCheckin];
+        $remoteCheckins = [
+            new Checkin(array_merge($localCheckin, ['id' => $checkinId, 'slug' => 'test-checkin'])),
+        ];
+
+        $mock = Mockery::mock(CheckinsClient::class, ['config' => $config]);
+        $mock->shouldReceive('listForProject')
+            ->twice()
+            ->andReturn($remoteCheckins);
+        $mock->shouldReceive('update')
+            ->once()
+            ->andReturn(new Checkin(array_merge(['id' => $checkinId], $localCheckin)));
+
+        $manager = new CheckinsManager($config, $mock);
+        echo 'is in sync';
+        $result = $manager->sync($checkinsConfig);
+
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+
+        $newCheckin = $result[0];
+        $this->assertEquals($checkinId, $newCheckin->id);
+        $this->assertNull($newCheckin->slug);
         $this->assertTrue($newCheckin->isInSync(new Checkin($localCheckin)));
     }
 
@@ -149,7 +198,9 @@ class CheckinsManagerTest extends TestCase
 
         $mock = Mockery::mock(CheckinsClient::class, ['config' => $config]);
         $mock->shouldReceive('listForProject')
+            ->twice()
             ->andReturn($remoteCheckins);
+        $mock->shouldNotReceive('update');
 
         $manager = new CheckinsManager($config, $mock);
         $result = $manager->sync($checkinsConfig);
@@ -186,8 +237,10 @@ class CheckinsManagerTest extends TestCase
 
         $mock = Mockery::mock(CheckinsClient::class, ['config' => $config]);
         $mock->shouldReceive('listForProject')
+            ->twice()
             ->andReturn($remoteCheckins);
         $mock->shouldReceive('remove')
+            ->once()
             ->withArgs(['p1234', 'c1234'])
             ->andReturn(true);
 

--- a/tests/CheckinsManagerTest.php
+++ b/tests/CheckinsManagerTest.php
@@ -39,6 +39,35 @@ class CheckinsManagerTest extends TestCase
     }
 
     /** @test */
+    public function throws_when_checkins_have_same_names_and_project_id()
+    {
+        $this->expectException(ServiceException::class);
+        $this->expectExceptionMessage('The configuration is invalid: Check-ins must have unique names and project ids');
+
+        $config = ['api_key' => '1234'];
+        $mock = Mockery::mock(Client::class);
+        $mock->shouldReceive('head')->andThrow(new Exception);
+
+        $client = new CheckinsClient(new Config($config), $mock);
+        $manager = new CheckinsManager($config, $client);
+        $checkinsConfig = [
+            [
+                'project_id' => '1234',
+                 'name' => 'Test Checkin',
+                'schedule_type' => 'simple',
+                'report_period' => '1 day',
+            ],
+            [
+                'project_id' => '1234',
+                'name' => 'Test Checkin',
+                'schedule_type' => 'simple',
+                'report_period' => '2 days',
+            ],
+        ];
+        $manager->sync($checkinsConfig);
+    }
+
+    /** @test */
     public function creates_checkin_when_not_found_in_project_checkins()
     {
         $config = [


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes #179 

## Todos
- [x] Tests
- [x] Do not allow check-ins with same name and project id
- [x] Always send optional values with empty string - this ensures that when values are unset are indeed sent to Honeybadger
- [x] Changelog Entry (unreleased)
- [x] Version bump
