### PR TITLE
feat: make project-id redundant for check-ins configuration api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.18.0] - 2023-12-28
+### Changed
+- Check-Ins: Remove project_id from configuration API
+
 ## [2.17.3] - 2023-12-04
 ### Fixed
 - Use $request->getContentTypeFormat

--- a/src/Contracts/Reporter.php
+++ b/src/Contracts/Reporter.php
@@ -35,15 +35,15 @@ interface Reporter
     public function rawNotification(callable $callable): array;
 
     /**
-     * Check-in using id or name.
-     * Pass check-in name only if check-ins are defined in your config file.
+     * Check-in using id or slug.
+     * Pass check-in slug only if check-ins are defined in your config file.
      *
-     * @param  string  $idOrName
+     * @param  string  $idOrSlug
      * @return void
      *
      * @throws \Honeybadger\Exceptions\ServiceException
      */
-    public function checkin(string $idOrName): void;
+    public function checkin(string $idOrSlug): void;
 
     /**
      * Attach some additional context to an error report. Context can be specified as a $key and $value, or as an array with key-value pairs.

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -120,40 +120,27 @@ class Honeybadger implements Reporter
     /**
      * {@inheritdoc}
      */
-    public function checkin(string $idOrName): void
+    public function checkin(string $idOrSlug): void
     {
-        $id = $this->getCheckInId($idOrName);
-        $this->client->checkIn($id);
-    }
-
-    /**
-     * Identify whether this could be the name of the check-in
-     * by looking at the check-ins array
-     *
-     * @param $identifier
-     * @return string
-     * @throws ServiceException
-     */
-    private function getCheckInId($identifier): string {
-        $id = $identifier;
-        $checkIns = $this->config['checkins'];
-        if (count($checkIns) > 0) {
-            $filtered = array_filter($checkIns, function ($checkIn) use ($identifier) {
-                return $checkIn->name === $identifier;
-            });
-            if (count($filtered) > 0) {
-                /** @var CheckIn $checkIn */
-                $checkIn = array_values($filtered)[0];
-                if (isset($checkIn->id)) {
-                    $id = $checkIn->id;
-                }
-                else if ($checkIn = $this->getCheckInByName($checkIn->projectId, $checkIn->name)) {
-                    $id = $checkIn->id;
-                }
-            }
+        if ($this->isCheckInSlug($idOrSlug)) {
+            $this->client->checkInWithSlug($this->config->get('api_key'), $idOrSlug);
+            return;
         }
 
-        return $id;
+        $this->client->checkIn($idOrSlug);
+    }
+
+    private function isCheckInSlug(string $idOrSlug): bool
+    {
+        $checkIns = $this->config->get('checkins') ?? [];
+        if (count($checkIns) > 0) {
+            $filtered = array_filter($checkIns, function ($checkIn) use ($idOrSlug) {
+                return $checkIn->slug === $idOrSlug;
+            });
+            return count($filtered) > 0;
+        }
+
+        return false;
     }
 
     /**

--- a/src/HoneybadgerClient.php
+++ b/src/HoneybadgerClient.php
@@ -57,6 +57,19 @@ class HoneybadgerClient extends ApiClient
         }
     }
 
+    public function checkInWithSlug(string $apiKey, string $checkInSlug): void
+    {
+        try {
+            $response = $this->client->head(sprintf('v1/check_in/%s/%s', $apiKey, $checkInSlug));
+
+            if ($response->getStatusCode() !== Response::HTTP_OK) {
+                $this->handleServiceException((new ServiceExceptionFactory($response))->make());
+            }
+        } catch (Throwable $e) {
+            $this->handleServiceException(ServiceException::generic($e));
+        }
+    }
+
     public function makeClient(): Client
     {
         return new Client([

--- a/tests/CheckInTest.php
+++ b/tests/CheckInTest.php
@@ -12,8 +12,7 @@ class CheckInTest extends TestCase {
     public function it_validates_simple_check_in()
     {
         $checkIn = new CheckIn([
-            'project_id' => 'p1234',
-            'name' => 'Test CheckIn',
+            'slug' => 'test-check-in',
             'schedule_type' => 'simple',
             'report_period' => '1 day',
             'grace_period' => '1 hour',
@@ -31,8 +30,7 @@ class CheckInTest extends TestCase {
     public function it_validates_cron_check_in()
     {
         $checkIn = new CheckIn([
-            'project_id' => 'p1234',
-            'name' => 'Test CheckIn',
+            'slug' => 'test-check-in',
             'schedule_type' => 'cron',
             'cron_schedule' => '* * * * *',
             'grace_period' => '1 hour',
@@ -47,13 +45,12 @@ class CheckInTest extends TestCase {
     }
 
     /** @test */
-    public function it_throws_for_missing_project_id()
+    public function it_throws_for_missing_slug()
     {
         $this->expectException(ServiceException::class);
-        $this->expectExceptionMessageMatches('/project_id is required for each check-in/');
+        $this->expectExceptionMessageMatches('/slug is required for each check-in/');
 
         $checkIn = new CheckIn([
-            'name' => 'Test CheckIn',
             'schedule_type' => 'simple',
             'grace_period' => '1 hour',
             'report_period' => '1 day',
@@ -69,8 +66,7 @@ class CheckInTest extends TestCase {
         $this->expectExceptionMessageMatches('/\[report_period\] is required for simple check-ins/');
 
         $checkIn = new CheckIn([
-            'project_id' => 'p1234',
-            'name' => 'Test CheckIn',
+            'slug' => 'test-check-in',
             'schedule_type' => 'simple',
             'grace_period' => '1 hour',
         ]);
@@ -85,8 +81,7 @@ class CheckInTest extends TestCase {
         $this->expectExceptionMessageMatches('/\[cron_schedule\] is required for cron check-ins/');
 
         $checkIn = new CheckIn([
-            'project_id' => 'p1234',
-            'name' => 'Test CheckIn',
+            'slug' => 'test-check-in',
             'schedule_type' => 'cron',
             'grace_period' => '1 hour'
         ]);
@@ -98,8 +93,7 @@ class CheckInTest extends TestCase {
     public function it_marks_check_in_as_deleted()
     {
         $checkIn = new CheckIn([
-            'project_id' => 'p1234',
-            'name' => 'Test CheckIn',
+            'slug' => 'test-check-in',
             'schedule_type' => 'simple',
             'report_period' => '1 day',
             'grace_period' => '1 hour'
@@ -114,7 +108,7 @@ class CheckInTest extends TestCase {
     public function it_does_not_include_null_values()
     {
         $checkIn = new CheckIn([
-            'name' => 'Test CheckIn',
+            'slug' => 'test-check-in',
             'schedule_type' => 'simple',
             'report_period' => '1 day',
             'grace_period' => '1 hour'

--- a/tests/CheckInsClientTest.php
+++ b/tests/CheckInsClientTest.php
@@ -45,6 +45,23 @@ class CheckInsClientTest extends TestCase
     }
 
     /** @test */
+    public function gets_project_id_from_project_api_key()
+    {
+        $config = new Config([
+            'api_key' => 'hbp_ABC',
+            'personal_auth_token' => '5678'
+        ]);
+        $mock = Mockery::mock(Client::class)->makePartial();
+        $mock->shouldReceive('get')
+            ->andReturn(new GuzzleResponse(Response::HTTP_OK, [], json_encode(['project' => ['id' => '1234']])));
+
+        $client = new CheckInsClient($config, $mock);
+        $projectId = $client->getProjectId($config->get('api_key'));
+
+        $this->assertEquals('1234', $projectId);
+    }
+
+    /** @test */
     public function creates_check_in_and_populates_id()
     {
         $config = new Config([
@@ -55,7 +72,7 @@ class CheckInsClientTest extends TestCase
             ->andReturn(new GuzzleResponse(Response::HTTP_CREATED, [], json_encode(['id' => '1234'])));
 
         $client = new CheckInsClient($config, $mock);
-        $checkIn = $client->create(new CheckIn());
+        $checkIn = $client->create('p1234', new CheckIn());
 
         $this->assertEquals('1234', $checkIn->id);
     }

--- a/tests/HoneybadgerTest.php
+++ b/tests/HoneybadgerTest.php
@@ -262,14 +262,22 @@ class HoneybadgerTest extends TestCase
     }
 
     /** @test */
-    public function it_sends_a_checkin_using_name() {
+    public function it_sends_a_checkin_using_slug() {
         $client = HoneybadgerClient::new([
+            //checkinsClient->getProjectId()
+            new Response(200, [], json_encode([
+                'project' => [
+                    [
+                        'id' => 'p1234',
+                    ],
+                ]
+            ])),
             //checkinsClient->listForProject()
             new Response(200, [], json_encode([
                 'results' => [
                     [
                         'id' => 'c1234',
-                        'name' => 'a simple checkin',
+                        'slug' => 'a-simple-check-in',
                         'schedule_type' => 'simple',
                         'report_period' => 60,
                     ],
@@ -288,16 +296,15 @@ class HoneybadgerTest extends TestCase
             ],
             'checkins' => [
                 [
-                    'project_id' => 'p1234',
-                    'name' => 'a simple checkin',
+                    'slug' => 'a-simple-check-in',
                     'schedule_type' => 'simple',
                     'report_period' => 60,
                 ],
             ]
-        ], $client->make())->checkin('a simple checkin');
+        ], $client->make())->checkin('a-simple-check-in');
 
         $request = $client->getLatestRequest();
-        $this->assertEquals('v1/check_in/c1234', $request->getUri()->getPath());
+        $this->assertEquals('v1/check_in/asdf/a-simple-check-in', $request->getUri()->getPath());
     }
 
     /** @test */


### PR DESCRIPTION
## Status
**READY**

## Description
Closes: #188

## Todos
- [x] Make name optional.
- [x] Make slug a required field.
- [x] Remove the project_id field from check-ins.
- [x] Assume all check-ins in a configuration file belong to the project_id that maps to the project API key.
- [x] Use slug to check-in instead of name, by [constructing the check-in url](https://docs.honeybadger.io/guides/check-ins/#slugs) with API key and slug.
- [x] Tests
- [x] [Documentation](https://github.com/honeybadger-io/docs/pull/391)
- [x] [Update](https://github.com/honeybadger-io/honeybadger-laravel/pull/116) Laravel package
- [x] Changelog Entry (unreleased)
