### PR TITLE
feat: events api integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## [2.19.0] - 2024-06-27
 ### Added
 - Events: Honeybadger.event() method to send custom events to Honeybadger
+- Events: Monolog logger to send logs as events to Honeybadger
 
 ## [2.18.0] - 2023-12-28
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.19.0] - 2024-06-27
+### Added
+- Events: Honeybadger.event() method to send custom events to Honeybadger
+
 ## [2.18.0] - 2023-12-28
 ### Changed
 - Check-Ins: Remove project_id from configuration API

--- a/src/BulkEventDispatcher.php
+++ b/src/BulkEventDispatcher.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Honeybadger;
+
+class BulkEventDispatcher
+{
+    const BULK_THRESHOLD = 50;
+    const DISPATCH_INTERVAL_MS = 100;
+
+    /**
+     * @var HoneybadgerClient
+     */
+    private $client;
+
+    /**
+     * @var array
+     */
+    private $events = [];
+
+    /**
+     * @var int
+     */
+    private $maxEvents;
+
+    /**
+     * @var int
+     */
+    private $dispatchInterval;
+
+    /**
+     * @var int
+     */
+    private $lastDispatchTime;
+
+    public function __construct(Config $config, HoneybadgerClient $client)
+    {
+        $this->client = $client;
+        $eventsConfig = $config->get('events') ?? [];
+        $this->maxEvents = $eventsConfig['bulk_threshold'] ?? self::BULK_THRESHOLD;
+        $this->dispatchInterval = $eventsConfig['dispatch_interval_ms'] ?? self::DISPATCH_INTERVAL_MS;
+        $this->lastDispatchTime = time();
+    }
+
+    public function addEvent($event)
+    {
+        $this->events[] = $event;
+
+        if (count($this->events) >= $this->maxEvents || (time() - $this->lastDispatchTime) >= $this->dispatchInterval) {
+            $this->dispatchEvents();
+        }
+    }
+
+    public function flushEvents()
+    {
+        if (empty($this->events)) {
+            return;
+        }
+
+        $this->dispatchEvents();
+    }
+
+    private function dispatchEvents()
+    {
+        if (empty($this->events)) {
+            return;
+        }
+
+        $this->client->events($this->events);
+
+        $this->events = [];
+        $this->lastDispatchTime = time();
+    }
+}

--- a/src/BulkEventDispatcher.php
+++ b/src/BulkEventDispatcher.php
@@ -5,7 +5,7 @@ namespace Honeybadger;
 class BulkEventDispatcher
 {
     const BULK_THRESHOLD = 50;
-    const DISPATCH_INTERVAL_MS = 100;
+    const DISPATCH_INTERVAL_SECONDS = 2;
 
     /**
      * @var HoneybadgerClient
@@ -37,7 +37,7 @@ class BulkEventDispatcher
         $this->client = $client;
         $eventsConfig = $config->get('events') ?? [];
         $this->maxEvents = $eventsConfig['bulk_threshold'] ?? self::BULK_THRESHOLD;
-        $this->dispatchInterval = $eventsConfig['dispatch_interval_ms'] ?? self::DISPATCH_INTERVAL_MS;
+        $this->dispatchInterval = $eventsConfig['dispatch_interval_seconds'] ?? self::DISPATCH_INTERVAL_SECONDS;
         $this->lastDispatchTime = time();
     }
 
@@ -52,16 +52,20 @@ class BulkEventDispatcher
 
     public function flushEvents()
     {
-        if (empty($this->events)) {
+        if (!$this->hasEvents()) {
             return;
         }
 
         $this->dispatchEvents();
     }
 
+    public function hasEvents(): bool {
+        return !empty($this->events);
+    }
+
     private function dispatchEvents()
     {
-        if (empty($this->events)) {
+        if (!$this->hasEvents()) {
             return;
         }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -54,6 +54,7 @@ class Config extends Repository
             'handlers' => [
                 'exception' => true,
                 'error' => true,
+                'shutdown' => true,
             ],
             'client' => [
                 'timeout' => 15,
@@ -69,6 +70,11 @@ class Config extends Repository
                 'enabled' => true,
             ],
             'checkins' => [],
+            'events' => [
+                'enabled' => false,
+                'bulk_threshold' => 50,
+                'dispatch_interval_ms' => 100
+            ],
         ], $config);
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -72,8 +72,8 @@ class Config extends Repository
             'checkins' => [],
             'events' => [
                 'enabled' => false,
-                'bulk_threshold' => 50,
-                'dispatch_interval_seconds' => 2
+                'bulk_threshold' => BulkEventDispatcher::BULK_THRESHOLD,
+                'dispatch_interval_seconds' => BulkEventDispatcher::DISPATCH_INTERVAL_SECONDS
             ],
         ], $config);
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -27,7 +27,7 @@ class Config extends Repository
      */
     private function mergeConfig($config = []): array
     {
-        return array_merge([
+        $result = array_merge([
             'api_key' => null,
             'personal_auth_token' => null,
             'endpoint' => Honeybadger::API_URL,
@@ -73,8 +73,14 @@ class Config extends Repository
             'events' => [
                 'enabled' => false,
                 'bulk_threshold' => 50,
-                'dispatch_interval_ms' => 100
+                'dispatch_interval_seconds' => 2
             ],
         ], $config);
+
+        if (!isset($result['handlers']['shutdown'])) {
+            $result['handlers']['shutdown'] = false;
+        }
+
+        return $result;
     }
 }

--- a/src/Contracts/Reporter.php
+++ b/src/Contracts/Reporter.php
@@ -74,4 +74,25 @@ interface Reporter
      * Clear all breadcrumbs and context.
      */
     public function clear(): self;
+
+    /**
+     * Log an event to the Events API (Honeybadger Insights).
+     * An event is a collection of properties that may be useful later (the more, the better).
+     * They're the best way to prepare for unknown unknowns — the things you can't anticipate before an incident.
+     * Send events to Honeybadger and generate insights around your application's performance and usage.
+     *
+     * @param string $eventType
+     * @param array $payload
+     *
+     * @return void
+     */
+    public function event(string $eventType, array $payload = []): void;
+
+    /**
+     * Flush all events from the queue.
+     * Useful when you want to ensure that all events are sent before the script ends.
+     *
+     * @return void
+     */
+    public function flushEvents(): void;
 }

--- a/src/Contracts/Reporter.php
+++ b/src/Contracts/Reporter.php
@@ -80,13 +80,16 @@ interface Reporter
      * An event is a collection of properties that may be useful later (the more, the better).
      * They're the best way to prepare for unknown unknowns — the things you can't anticipate before an incident.
      * Send events to Honeybadger and generate insights around your application's performance and usage.
+     * If this function is called only with 1 argument:
+     *  - it must be an array and have at least a field 'event_type'.
+     *  - it will be treated as the payload and the second argument will be ignored.
      *
-     * @param string $eventType
-     * @param array $payload
+     * @param string | array $eventTypeOrPayload
+     * @param array | null $payload
      *
      * @return void
      */
-    public function event(string $eventType, array $payload = []): void;
+    public function event($eventTypeOrPayload, array $payload = null): void;
 
     /**
      * Flush all events from the queue.

--- a/src/Handlers/ShutdownHandler.php
+++ b/src/Handlers/ShutdownHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Honeybadger\Handlers;
+
+use Honeybadger\Contracts\Handler as HandlerContract;
+
+class ShutdownHandler extends Handler implements HandlerContract
+{
+    /**
+     * @return void
+     */
+    public function register(): void
+    {
+        register_shutdown_function([$this, 'handle']);
+    }
+
+    /**
+     * @return void
+     *
+     * @throws \Honeybadger\Exceptions\ServiceException
+     */
+    public function handle(): void
+    {
+        $this->honeybadger->flushEvents();
+    }
+}

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -214,9 +214,20 @@ class Honeybadger implements Reporter
     /**
      * {@inheritdoc}
      */
-    public function event(string $eventType, array $payload = []): void
+    public function event($eventTypeOrPayload, array $payload = null): void
     {
         if (!$this->config['events']['enabled']) {
+            return;
+        }
+
+        if (is_array($eventTypeOrPayload)) {
+            $payload = $eventTypeOrPayload;
+            $eventType = $payload['event_type'] ?? null;
+        } else {
+            $eventType = $eventTypeOrPayload;
+        }
+
+        if (empty($eventType) || empty($payload)) {
             return;
         }
 
@@ -224,6 +235,12 @@ class Honeybadger implements Reporter
             ['event_type' => $eventType, 'ts' => (new DateTime())->format(DATE_ATOM)],
             $payload
         );
+
+        // if 'ts' is set, we need to make sure it's a string in the correct format
+        if (isset($event['ts']) && $event['ts'] instanceof DateTime) {
+            $event['ts'] = $event['ts']->format(DATE_ATOM);
+        }
+
         $this->events->addEvent($event);
     }
 

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -22,7 +22,7 @@ class Honeybadger implements Reporter
     /**
      * SDK Version.
      */
-    const VERSION = '2.18.0';
+    const VERSION = '2.19.0';
 
     /**
      * Honeybadger API URL.

--- a/src/HoneybadgerClient.php
+++ b/src/HoneybadgerClient.php
@@ -70,6 +70,29 @@ class HoneybadgerClient extends ApiClient
         }
     }
 
+    /**
+     * @param array $events
+     * @return void
+     */
+    public function events(array $events): void
+    {
+        try {
+            $ndjson = implode("\n", array_map('json_encode', $events));
+            $response = $this->client->post(
+                'v1/events',
+                ['body' => $ndjson]
+            );
+        } catch (Throwable $e) {
+            $this->handleServiceException(ServiceException::generic($e));
+
+            return;
+        }
+
+        if ($response->getStatusCode() !== Response::HTTP_CREATED) {
+            $this->handleServiceException((new ServiceExceptionFactory($response))->make());
+        }
+    }
+
     public function makeClient(): Client
     {
         return new Client([

--- a/src/LogEventHandler.php
+++ b/src/LogEventHandler.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Honeybadger;
+
+use Honeybadger\Contracts\Reporter;
+use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Level;
+use Monolog\LogRecord;
+
+class LogEventHandler extends AbstractProcessingHandler
+{
+    /**
+     * @var \Honeybadger\Contracts\Reporter
+     */
+    protected $honeybadger;
+
+    /**
+     * @param \Honeybadger\Contracts\Reporter $honeybadger
+     * @param $level
+     * @param bool $bubble
+     */
+    public function __construct(Reporter $honeybadger, $level = Level::Info, bool $bubble = true)
+    {
+        parent::__construct($level, $bubble);
+
+        $this->honeybadger = $honeybadger;
+    }
+
+    /**
+     * @param array|\Monolog\LogRecord $record
+     */
+    protected function write($record): void
+    {
+        if (!$this->isHandling($record)) {
+            return;
+        }
+
+        $eventPayload = $this->getEventPayloadFromMonologRecord($record);
+        $this->honeybadger->event('log', $eventPayload);
+    }
+
+    protected function getEventPayloadFromMonologRecord(LogRecord $record): array {
+        $payload = [
+            'ts' => $record->datetime->format(DATE_ATOM),
+            'severity' => strtolower($record->level->getName()),
+            'message' => $record->message,
+            'channel' => $record->channel,
+        ];
+
+        if (isset($record->context) && $record->context != null) {
+            $payload = array_merge($payload, $record->context);
+        }
+
+        return $payload;
+    }
+}

--- a/tests/BulkEventDispatcherTest.php
+++ b/tests/BulkEventDispatcherTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Honeybadger\Tests;
+
+use DateTime;
+use Honeybadger\BulkEventDispatcher;
+use Honeybadger\Config;
+use Honeybadger\HoneybadgerClient;
+use PHPUnit\Framework\TestCase;
+use Mockery;
+
+class BulkEventDispatcherTest extends TestCase {
+
+    /** @test */
+    public function it_initializes_the_bulk_event_dispatcher() {
+        $config = new Config([
+            'api_key' => 'hbp_ABC',
+        ]);
+        $hbMock = Mockery::mock(HoneybadgerClient::class)->makePartial();
+        $dispatcher = new BulkEventDispatcher($config, $hbMock);
+        $this->assertInstanceOf(BulkEventDispatcher::class, $dispatcher);
+    }
+
+    /** @test */
+    public function it_adds_event_to_the_queue() {
+        $config = new Config([
+            'api_key' => 'hbp_ABC',
+        ]);
+        $hbMock = $this->createMock(HoneybadgerClient::class);
+        $dispatcher = new BulkEventDispatcher($config, $hbMock);
+        $dispatcher->addEvent(['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_ATOM)]);
+        $this->assertTrue($dispatcher->hasEvents());
+    }
+
+    /** @test */
+    public function it_sends_events_when_threshold_is_reached() {
+        $config = new Config([
+            'api_key' => 'hbp_ABC',
+            'events' => [
+                'bulk_threshold' => 2,
+                'dispatch_interval_seconds' => 2,
+            ]
+        ]);
+        $events = [
+            ['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_ATOM), 'message' => 'test 1'],
+            ['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_ATOM), 'message' => 'test 2'],
+        ];
+        $hbMock = $this->createMock(HoneybadgerClient::class);
+        $hbMock->expects($this->once())->method('events')->with($events);
+        $dispatcher = new BulkEventDispatcher($config, $hbMock);
+        $dispatcher->addEvent($events[0]);
+        $this->assertTrue($dispatcher->hasEvents());
+        $dispatcher->addEvent($events[1]);
+        $this->assertFalse($dispatcher->hasEvents());
+    }
+
+    /** @test */
+    public function it_sends_events_when_interval_is_reached() {
+        $config = new Config([
+            'api_key' => 'hbp_ABC',
+            'events' => [
+                'bulk_threshold' => 50,
+                'dispatch_interval_seconds' => 2,
+            ]
+        ]);
+        $events = [
+            ['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_ATOM), 'message' => 'test 1'],
+            ['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_ATOM), 'message' => 'test 2'],
+        ];
+        $hbMock = $this->createMock(HoneybadgerClient::class);
+        $hbMock->expects($this->once())->method('events')->with($events);
+        $dispatcher = new BulkEventDispatcher($config, $hbMock);
+        $dispatcher->addEvent($events[0]);
+        $this->assertTrue($dispatcher->hasEvents());
+        sleep(2);
+        $dispatcher->addEvent($events[1]);
+        $this->assertFalse($dispatcher->hasEvents());
+    }
+
+    /** @test */
+    public function it_flushes_events() {
+        $config = new Config([
+            'api_key' => 'hbp_ABC',
+            'events' => [
+                'bulk_threshold' => 50,
+                'dispatch_interval_seconds' => 2,
+            ]
+        ]);
+        $events = [
+            ['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_ATOM), 'message' => 'test 1'],
+            ['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_ATOM), 'message' => 'test 2'],
+        ];
+        $hbMock = $this->createMock(HoneybadgerClient::class);
+        $hbMock->expects($this->once())->method('events')->with($events);
+        $dispatcher = new BulkEventDispatcher($config, $hbMock);
+        $dispatcher->addEvent($events[0]);
+        $dispatcher->addEvent($events[1]);
+        $this->assertTrue($dispatcher->hasEvents());
+        $dispatcher->flushEvents();
+        $this->assertFalse($dispatcher->hasEvents());
+    }
+
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -39,6 +39,7 @@ class ConfigTest extends TestCase
             'handlers' => [
                 'exception' => true,
                 'error' => true,
+                'shutdown' => true,
             ],
             'client' => [
                 'timeout' => 15,
@@ -54,7 +55,12 @@ class ConfigTest extends TestCase
             'breadcrumbs' => [
                 'enabled' => true,
             ],
-            'checkins' => []
+            'checkins' => [],
+            'events' => [
+                'enabled' => false,
+                'bulk_threshold' => 50,
+                'dispatch_interval_seconds' => 2,
+            ],
         ], $config);
     }
 }

--- a/tests/HoneybadgerClientTest.php
+++ b/tests/HoneybadgerClientTest.php
@@ -2,6 +2,7 @@
 
 namespace Honeybadger\Tests;
 
+use DateTime;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response as GuzzleResponse;
@@ -41,6 +42,27 @@ class HoneybadgerClientTest extends TestCase
 
         $client = new HoneybadgerClient($config, $mock);
         $client->checkIn('1234');
+    }
+
+    /** @test */
+    public function throws_generic_exception_for_events()
+    {
+        $this->expectException(ServiceException::class);
+        $this->expectExceptionMessage('There was an error sending the payload to Honeybadger');
+
+        $config = new Config(['api_key' => '1234']);
+        $mock = Mockery::mock(Client::class)->makePartial();
+        $mock->shouldReceive('post')->andThrow(new Exception);
+
+        $client = new HoneybadgerClient($config, $mock);
+        $events = [
+            [
+                'event_type' => 'log',
+                'ts' => (new DateTime())->format(DATE_ATOM),
+                'message' => 'Test message'
+            ]
+        ];
+        $client->events($events);
     }
 
     /** @test */

--- a/tests/HoneybadgerTest.php
+++ b/tests/HoneybadgerTest.php
@@ -2,8 +2,11 @@
 
 namespace Honeybadger\Tests;
 
+use DateTime;
 use Exception;
 use GuzzleHttp\Psr7\Response;
+use Honeybadger\BulkEventDispatcher;
+use Honeybadger\Config;
 use Honeybadger\Exceptions\ServiceException;
 use Honeybadger\Handlers\ErrorHandler;
 use Honeybadger\Handlers\ExceptionHandler;
@@ -892,5 +895,65 @@ class HoneybadgerTest extends TestCase
         $this->assertIsArray($notification['breadcrumbs']);
         $this->assertFalse($notification['breadcrumbs']['enabled']);
         $this->assertCount(0, $notification['breadcrumbs']['trail']);
+    }
+
+    /** @test */
+    public function wont_send_event_if_disabled() {
+        $eventsDispatcher = $this->createMock(BulkEventDispatcher::class);
+        $eventsDispatcher->expects($this->never())->method('addEvent');
+
+        $client = HoneybadgerClient::new([
+            new Response(201),
+        ]);
+        $badger = Honeybadger::new([
+            'api_key' => 'asdf',
+            'events' => [
+                'enabled' => false,
+                'bulk_threshold' => 1,
+            ],
+        ], $client->make(), $eventsDispatcher);
+
+        $badger->event('log', ['message' => 'Test message']);
+    }
+
+    /** @test */
+    public function it_adds_event_type_and_ts_to_event_payload() {
+        $eventsDispatcher = $this->createMock(BulkEventDispatcher::class);
+        $eventsDispatcher
+            ->expects($this->once())
+            ->method('addEvent')
+            ->with([
+                'event_type' => 'log',
+                'ts' => (new DateTime())->format(DATE_ATOM),
+                'message' => 'Test message',
+            ]);
+
+        $client = HoneybadgerClient::new([
+            new Response(201),
+        ]);
+        $badger = Honeybadger::new([
+            'api_key' => 'asdf',
+            'events' => [
+                'enabled' => true,
+            ],
+        ], $client->make(), $eventsDispatcher);
+
+        $badger->event('log', ['message' => 'Test message']);
+    }
+
+    /** @test */
+    public function it_queues_an_event() {
+        $config = new Config([
+            'api_key' => 'asdf',
+            'events' => [
+                'enabled' => true,
+            ],
+        ]);
+        $client = new \Honeybadger\HoneybadgerClient($config);
+        $eventsDispatcher = new BulkEventDispatcher($config, $client);
+        $badger = Honeybadger::new($config->all(), $client->makeClient(), $eventsDispatcher);
+
+        $badger->event('log', ['message' => 'Test message']);
+        $this->assertTrue($eventsDispatcher->hasEvents());
     }
 }

--- a/tests/HoneybadgerTest.php
+++ b/tests/HoneybadgerTest.php
@@ -949,11 +949,29 @@ class HoneybadgerTest extends TestCase
                 'enabled' => true,
             ],
         ]);
-        $client = new \Honeybadger\HoneybadgerClient($config);
+        $client = $this->createPartialMock(\Honeybadger\HoneybadgerClient::class, ['events', 'makeClient']);
         $eventsDispatcher = new BulkEventDispatcher($config, $client);
         $badger = Honeybadger::new($config->all(), $client->makeClient(), $eventsDispatcher);
 
         $badger->event('log', ['message' => 'Test message']);
         $this->assertTrue($eventsDispatcher->hasEvents());
+    }
+
+    /** @test */
+    public function it_flushes_events() {
+        $config = new Config([
+            'api_key' => 'asdf',
+            'events' => [
+                'enabled' => true,
+            ],
+        ]);
+        $client = $this->createPartialMock(\Honeybadger\HoneybadgerClient::class, ['events', 'makeClient']);
+        $eventsDispatcher = new BulkEventDispatcher($config, $client);
+        $badger = Honeybadger::new($config->all(), $client->makeClient(), $eventsDispatcher);
+
+        $badger->event('log', ['message' => 'Test message']);
+        $this->assertTrue($eventsDispatcher->hasEvents());
+        $badger->flushEvents();
+        $this->assertFalse($eventsDispatcher->hasEvents());
     }
 }

--- a/tests/HoneybadgerTest.php
+++ b/tests/HoneybadgerTest.php
@@ -958,6 +958,38 @@ class HoneybadgerTest extends TestCase
     }
 
     /** @test */
+    public function it_queues_an_event_with_payload_only() {
+        $config = new Config([
+            'api_key' => 'asdf',
+            'events' => [
+                'enabled' => true,
+            ],
+        ]);
+        $client = $this->createPartialMock(\Honeybadger\HoneybadgerClient::class, ['events', 'makeClient']);
+        $eventsDispatcher = new BulkEventDispatcher($config, $client);
+        $badger = Honeybadger::new($config->all(), $client->makeClient(), $eventsDispatcher);
+
+        $badger->event(['event_type' => 'log', 'message' => 'Test message']);
+        $this->assertTrue($eventsDispatcher->hasEvents());
+    }
+
+    /** @test */
+    public function wont_send_event_if_payload_is_missing_event_type() {
+        $config = new Config([
+            'api_key' => 'asdf',
+            'events' => [
+                'enabled' => true,
+            ],
+        ]);
+        $client = $this->createPartialMock(\Honeybadger\HoneybadgerClient::class, ['events', 'makeClient']);
+        $eventsDispatcher = new BulkEventDispatcher($config, $client);
+        $badger = Honeybadger::new($config->all(), $client->makeClient(), $eventsDispatcher);
+
+        $badger->event(['message' => 'Test message']);
+        $this->assertFalse($eventsDispatcher->hasEvents());
+    }
+
+    /** @test */
     public function it_flushes_events() {
         $config = new Config([
             'api_key' => 'asdf',

--- a/tests/LogEventHandlerTest.php
+++ b/tests/LogEventHandlerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Honeybadger\Tests;
+
+use Honeybadger\BulkEventDispatcher;
+use Honeybadger\Config;
+use Honeybadger\Contracts\Reporter;
+use Honeybadger\Honeybadger;
+use Honeybadger\HoneybadgerClient;
+use Honeybadger\LogEventHandler;
+use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Level;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+
+class LogEventHandlerTest extends TestCase
+{
+    /** @test */
+    public function it_can_be_created()
+    {
+        $reporter = $this->createMock(Reporter::class);
+
+        $this->assertInstanceOf(
+            AbstractProcessingHandler::class,
+            new LogEventHandler($reporter)
+        );
+    }
+
+    /** @test */
+    public function it_formats_a_log_for_events_api()
+    {
+        $client = $this->createMock(HoneybadgerClient::class);
+        $config = new Config([
+            'events' => [
+                'enabled' => true
+            ]
+        ]);
+        $eventsDispatcher = new class($config, $client) extends BulkEventDispatcher {
+            public $events = [];
+
+            public function __construct(Config $config, HoneybadgerClient $client)
+            {
+                parent::__construct($config, $client);
+            }
+
+            public function addEvent($event): void
+            {
+                $this->events[] = $event;
+            }
+        };
+        $reporter = new Honeybadger($config->all(), null, $eventsDispatcher);
+        $logger = new Logger('test-logger');
+        $logger->pushHandler(new LogEventHandler($reporter));
+
+        $logger->info('Test log message', ['some' => 'data']);
+
+        $this->assertEquals([[
+            'event_type' => 'log',
+            'ts' => (new \DateTime())->format(DATE_ATOM),
+            'channel' => 'test-logger',
+            'message' => 'Test log message',
+            'severity' => 'info',
+            'some' => 'data',
+        ]], $eventsDispatcher->events);
+    }
+
+    /** @test */
+    public function it_ignores_logs_below_its_minimum_level()
+    {
+        $client = $this->createMock(HoneybadgerClient::class);
+        $config = new Config([
+            'events' => [
+                'enabled' => true
+            ]
+        ]);
+        $eventsDispatcher = new class($config, $client) extends BulkEventDispatcher {
+            public $events = [];
+
+            public function __construct(Config $config, HoneybadgerClient $client)
+            {
+                parent::__construct($config, $client);
+            }
+
+            public function addEvent($event): void
+            {
+                $this->events[] = $event;
+            }
+        };
+        $reporter = new Honeybadger($config->all(), null, $eventsDispatcher);
+        $logger = new Logger('test-logger');
+        $logger->pushHandler(new LogEventHandler($reporter, Level::Info));
+
+        $logger->debug('Test debug message', ['some' => 'data']);
+        $logger->warning('Test warning message', ['some' => 'data']);
+
+        $this->assertEquals([[
+            'event_type' => 'log',
+            'ts' => (new \DateTime())->format(DATE_ATOM),
+            'channel' => 'test-logger',
+            'message' => 'Test warning message',
+            'severity' => 'warning',
+            'some' => 'data',
+        ]], $eventsDispatcher->events);
+    }
+}


### PR DESCRIPTION
## Status
**READY**

## Description
Honeybadger Insights integration. Adds a `Honeybadger.event()` function that allows sending events to Insights.
Closes: #190

## Todos
- [x] Honeybadger.event()
- [x] `BulkEventDispatcher` to send events in bulk
- [x] Shutdown handler to flush events
- [x] Configuration to enable events, register shutdown handler, set number for bulk events and threshold in ms to call the api
- [x] Tests
- [x] Manual Tests (Honeybadger.event, Honeybadger.flushEvents, shutdown handler)
- [x] Changelog Entry (unreleased)
- [x] From #192 -  LogEventHandler

## Next up
- #192 
- https://github.com/honeybadger-io/docs/issues/503

