### PR TITLE
feat: events api log instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## [2.19.0] - 2024-06-27
 ### Added
 - Events: Honeybadger.event() method to send custom events to Honeybadger
+- Events: Monolog logger to send logs as events to Honeybadger
 
 ## [2.18.0] - 2023-12-28
 ### Changed

--- a/src/Contracts/Reporter.php
+++ b/src/Contracts/Reporter.php
@@ -80,13 +80,16 @@ interface Reporter
      * An event is a collection of properties that may be useful later (the more, the better).
      * They're the best way to prepare for unknown unknowns — the things you can't anticipate before an incident.
      * Send events to Honeybadger and generate insights around your application's performance and usage.
+     * If this function is called only with 1 argument:
+     *  - it must be an array and have at least a field 'event_type'.
+     *  - it will be treated as the payload and the second argument will be ignored.
      *
-     * @param string $eventType
-     * @param array $payload
+     * @param string | array $eventTypeOrPayload
+     * @param array | null $payload
      *
      * @return void
      */
-    public function event(string $eventType, array $payload = []): void;
+    public function event($eventTypeOrPayload, array $payload = null): void;
 
     /**
      * Flush all events from the queue.

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -224,6 +224,12 @@ class Honeybadger implements Reporter
             ['event_type' => $eventType, 'ts' => (new DateTime())->format(DATE_ATOM)],
             $payload
         );
+
+        // if 'ts' is set, we need to make sure it's a string in the correct format
+        if (isset($event['ts']) && $event['ts'] instanceof DateTime) {
+            $event['ts'] = $event['ts']->format(DATE_ATOM);
+        }
+
         $this->events->addEvent($event);
     }
 

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -214,9 +214,20 @@ class Honeybadger implements Reporter
     /**
      * {@inheritdoc}
      */
-    public function event(string $eventType, array $payload = []): void
+    public function event($eventTypeOrPayload, array $payload = null): void
     {
         if (!$this->config['events']['enabled']) {
+            return;
+        }
+
+        if (is_array($eventTypeOrPayload)) {
+            $payload = $eventTypeOrPayload;
+            $eventType = $payload['event_type'] ?? null;
+        } else {
+            $eventType = $eventTypeOrPayload;
+        }
+
+        if (empty($eventType) || empty($payload)) {
             return;
         }
 

--- a/src/LogEventHandler.php
+++ b/src/LogEventHandler.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Honeybadger;
+
+use Honeybadger\Contracts\Reporter;
+use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Level;
+use Monolog\LogRecord;
+
+class LogEventHandler extends AbstractProcessingHandler
+{
+    /**
+     * @var \Honeybadger\Contracts\Reporter
+     */
+    protected $honeybadger;
+
+    /**
+     * @param \Honeybadger\Contracts\Reporter $honeybadger
+     * @param $level
+     * @param bool $bubble
+     */
+    public function __construct(Reporter $honeybadger, $level = Level::Info, bool $bubble = true)
+    {
+        parent::__construct($level, $bubble);
+
+        $this->honeybadger = $honeybadger;
+    }
+
+    /**
+     * @param array|\Monolog\LogRecord $record
+     */
+    protected function write($record): void
+    {
+        if (!$this->isHandling($record)) {
+            return;
+        }
+
+        $eventPayload = $this->getEventPayloadFromMonologRecord($record);
+        $this->honeybadger->event('log', $eventPayload);
+    }
+
+    protected function getEventPayloadFromMonologRecord(LogRecord $record): array {
+        $payload = [
+            'ts' => $record->datetime->format(DATE_ATOM),
+            'severity' => strtolower($record->level->getName()),
+            'message' => $record->message,
+            'channel' => $record->channel,
+        ];
+
+        if (isset($record->context) && $record->context != null) {
+            $payload = array_merge($payload, $record->context);
+        }
+
+        return $payload;
+    }
+}

--- a/tests/HoneybadgerTest.php
+++ b/tests/HoneybadgerTest.php
@@ -958,6 +958,38 @@ class HoneybadgerTest extends TestCase
     }
 
     /** @test */
+    public function it_queues_an_event_with_payload_only() {
+        $config = new Config([
+            'api_key' => 'asdf',
+            'events' => [
+                'enabled' => true,
+            ],
+        ]);
+        $client = $this->createPartialMock(\Honeybadger\HoneybadgerClient::class, ['events', 'makeClient']);
+        $eventsDispatcher = new BulkEventDispatcher($config, $client);
+        $badger = Honeybadger::new($config->all(), $client->makeClient(), $eventsDispatcher);
+
+        $badger->event(['event_type' => 'log', 'message' => 'Test message']);
+        $this->assertTrue($eventsDispatcher->hasEvents());
+    }
+
+    /** @test */
+    public function wont_send_event_if_payload_is_missing_event_type() {
+        $config = new Config([
+            'api_key' => 'asdf',
+            'events' => [
+                'enabled' => true,
+            ],
+        ]);
+        $client = $this->createPartialMock(\Honeybadger\HoneybadgerClient::class, ['events', 'makeClient']);
+        $eventsDispatcher = new BulkEventDispatcher($config, $client);
+        $badger = Honeybadger::new($config->all(), $client->makeClient(), $eventsDispatcher);
+
+        $badger->event(['message' => 'Test message']);
+        $this->assertFalse($eventsDispatcher->hasEvents());
+    }
+
+    /** @test */
     public function it_flushes_events() {
         $config = new Config([
             'api_key' => 'asdf',

--- a/tests/LogEventHandlerTest.php
+++ b/tests/LogEventHandlerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Honeybadger\Tests;
+
+use Honeybadger\BulkEventDispatcher;
+use Honeybadger\Config;
+use Honeybadger\Contracts\Reporter;
+use Honeybadger\Honeybadger;
+use Honeybadger\HoneybadgerClient;
+use Honeybadger\LogEventHandler;
+use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Level;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+
+class LogEventHandlerTest extends TestCase
+{
+    /** @test */
+    public function it_can_be_created()
+    {
+        $reporter = $this->createMock(Reporter::class);
+
+        $this->assertInstanceOf(
+            AbstractProcessingHandler::class,
+            new LogEventHandler($reporter)
+        );
+    }
+
+    /** @test */
+    public function it_formats_a_log_for_events_api()
+    {
+        $client = $this->createMock(HoneybadgerClient::class);
+        $config = new Config([
+            'events' => [
+                'enabled' => true
+            ]
+        ]);
+        $eventsDispatcher = new class($config, $client) extends BulkEventDispatcher {
+            public $events = [];
+
+            public function __construct(Config $config, HoneybadgerClient $client)
+            {
+                parent::__construct($config, $client);
+            }
+
+            public function addEvent($event): void
+            {
+                $this->events[] = $event;
+            }
+        };
+        $reporter = new Honeybadger($config->all(), null, $eventsDispatcher);
+        $logger = new Logger('test-logger');
+        $logger->pushHandler(new LogEventHandler($reporter));
+
+        $logger->info('Test log message', ['some' => 'data']);
+
+        $this->assertEquals([[
+            'event_type' => 'log',
+            'ts' => (new \DateTime())->format(DATE_ATOM),
+            'channel' => 'test-logger',
+            'message' => 'Test log message',
+            'severity' => 'info',
+            'some' => 'data',
+        ]], $eventsDispatcher->events);
+    }
+
+    /** @test */
+    public function it_ignores_logs_below_its_minimum_level()
+    {
+        $client = $this->createMock(HoneybadgerClient::class);
+        $config = new Config([
+            'events' => [
+                'enabled' => true
+            ]
+        ]);
+        $eventsDispatcher = new class($config, $client) extends BulkEventDispatcher {
+            public $events = [];
+
+            public function __construct(Config $config, HoneybadgerClient $client)
+            {
+                parent::__construct($config, $client);
+            }
+
+            public function addEvent($event): void
+            {
+                $this->events[] = $event;
+            }
+        };
+        $reporter = new Honeybadger($config->all(), null, $eventsDispatcher);
+        $logger = new Logger('test-logger');
+        $logger->pushHandler(new LogEventHandler($reporter, Level::Info));
+
+        $logger->debug('Test debug message', ['some' => 'data']);
+        $logger->warning('Test warning message', ['some' => 'data']);
+
+        $this->assertEquals([[
+            'event_type' => 'log',
+            'ts' => (new \DateTime())->format(DATE_ATOM),
+            'channel' => 'test-logger',
+            'message' => 'Test warning message',
+            'severity' => 'warning',
+            'some' => 'data',
+        ]], $eventsDispatcher->events);
+    }
+}


### PR DESCRIPTION
## Status
**READY**

## Description
Custom monolog handler to sent monolog records to Events API.
Closes #192.

## Todos
- [x] `LogEventHandler`
- [x] Tests
- [x] Changelog Entry (unreleased)
