### PR TITLE
fix: check if events are enabled when calling flushEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [2.19.2] - 2024-07-01
+## [2.19.2] - 2024-07-06
 ### Fixed
 - Events: Honeybadger.flushEvents() should check if events are enabled before sending to Honeybadger
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.19.2] - 2024-07-01
+### Fixed
+- Events: Honeybadger.flushEvents() should check if events are enabled before sending to Honeybadger
+### Changed
+- Events: Register shutdown handler by default
+
 ## [2.19.1] - 2024-06-29
 ### Fixed
 - Events: Allow Honeybadger.event() without event_type

--- a/src/Config.php
+++ b/src/Config.php
@@ -78,7 +78,9 @@ class Config extends Repository
         ], $config);
 
         if (!isset($result['handlers']['shutdown'])) {
-            $result['handlers']['shutdown'] = false;
+            // the 'shutdown' field is new, array_merge only merges on the first level
+            // so we need to manually set it if the config has a 'handlers' key but not a 'shutdown' key inside
+            $result['handlers']['shutdown'] = true;
         }
 
         return $result;

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -22,7 +22,7 @@ class Honeybadger implements Reporter
     /**
      * SDK Version.
      */
-    const VERSION = '2.19.1';
+    const VERSION = '2.19.2';
 
     /**
      * Honeybadger API URL.
@@ -249,6 +249,10 @@ class Honeybadger implements Reporter
      */
     public function flushEvents(): void
     {
+        if (!$this->config['events']['enabled']) {
+            return;
+        }
+
         $this->events->flushEvents();
     }
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -63,4 +63,66 @@ class ConfigTest extends TestCase
             ],
         ], $config);
     }
+
+    /** @test */
+    public function it_set_shutdown_handler_to_true_by_default()
+    {
+        $config = (new Config([
+            'api_key' => '1234',
+            'handlers' => [
+                'exception' => true,
+                'error' => true,
+            ],
+        ]))->all();
+
+        $this->assertArrayHasKey('service_exception_handler', $config);
+        unset($config['service_exception_handler']);
+
+        $this->assertEquals([
+            'api_key' => '1234',
+            'personal_auth_token' => null,
+            'endpoint' => Honeybadger::API_URL,
+            'notifier' => [
+                'name' => 'honeybadger-php',
+                'url' => 'https://github.com/honeybadger-io/honeybadger-php',
+                'version' => Honeybadger::VERSION,
+            ],
+            'environment' => [
+                'filter' => [],
+                'include' => [],
+            ],
+            'request' => [
+                'filter' => [],
+            ],
+            'version' => '',
+            'hostname' => gethostname(),
+            'project_root' => '',
+            'environment_name' => 'production',
+            'handlers' => [
+                'exception' => true,
+                'error' => true,
+                'shutdown' => true,
+            ],
+            'client' => [
+                'timeout' => 15,
+                'proxy' => [],
+                'verify' => true,
+            ],
+            'excluded_exceptions' => [],
+            'capture_deprecations' => false,
+            'report_data' => true,
+            'vendor_paths' => [
+                'vendor\/.*',
+            ],
+            'breadcrumbs' => [
+                'enabled' => true,
+            ],
+            'checkins' => [],
+            'events' => [
+                'enabled' => false,
+                'bulk_threshold' => 50,
+                'dispatch_interval_seconds' => 2,
+            ],
+        ], $config);
+    }
 }


### PR DESCRIPTION
## Status
**READY**

## Description
- Adds a config check when calling `Honeybadger.flushEvents()`
- Registers shutdown handler by default
