### PR TITLE
fix: revert to deprecated version of logger levels for wider support

### DIFF
--- a/src/LogEventHandler.php
+++ b/src/LogEventHandler.php
@@ -4,7 +4,7 @@ namespace Honeybadger;
 
 use Honeybadger\Contracts\Reporter;
 use Monolog\Handler\AbstractProcessingHandler;
-use Monolog\Level;
+use Monolog\Logger;
 use Monolog\LogRecord;
 
 class LogEventHandler extends AbstractProcessingHandler
@@ -19,7 +19,7 @@ class LogEventHandler extends AbstractProcessingHandler
      * @param $level
      * @param bool $bubble
      */
-    public function __construct(Reporter $honeybadger, $level = Level::Info, bool $bubble = true)
+    public function __construct(Reporter $honeybadger, $level = Logger::INFO, bool $bubble = true)
     {
         parent::__construct($level, $bubble);
 

--- a/src/LogEventHandler.php
+++ b/src/LogEventHandler.php
@@ -27,7 +27,7 @@ class LogEventHandler extends AbstractProcessingHandler
     }
 
     /**
-     * @param array|\Monolog\LogRecord $record
+     * @param array|LogRecord $record
      */
     protected function write($record): void
     {
@@ -39,16 +39,20 @@ class LogEventHandler extends AbstractProcessingHandler
         $this->honeybadger->event('log', $eventPayload);
     }
 
-    protected function getEventPayloadFromMonologRecord(LogRecord $record): array {
+    /**
+     * @param array|LogRecord $record
+     * @return array
+     */
+    protected function getEventPayloadFromMonologRecord($record): array {
         $payload = [
-            'ts' => $record->datetime->format(DATE_ATOM),
-            'severity' => strtolower($record->level->getName()),
-            'message' => $record->message,
-            'channel' => $record->channel,
+            'ts' => $record['datetime']->format(DATE_ATOM),
+            'severity' => strtolower($record['level_name']),
+            'message' => $record['message'],
+            'channel' => $record['channel'],
         ];
 
-        if (isset($record->context) && $record->context != null) {
-            $payload = array_merge($payload, $record->context);
+        if (isset($record['context']) && $record['context'] != null) {
+            $payload = array_merge($payload, $record['context']);
         }
 
         return $payload;

--- a/tests/LogEventHandlerTest.php
+++ b/tests/LogEventHandlerTest.php
@@ -9,7 +9,6 @@ use Honeybadger\Honeybadger;
 use Honeybadger\HoneybadgerClient;
 use Honeybadger\LogEventHandler;
 use Monolog\Handler\AbstractProcessingHandler;
-use Monolog\Level;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 
@@ -88,7 +87,7 @@ class LogEventHandlerTest extends TestCase
         };
         $reporter = new Honeybadger($config->all(), null, $eventsDispatcher);
         $logger = new Logger('test-logger');
-        $logger->pushHandler(new LogEventHandler($reporter, Level::Info));
+        $logger->pushHandler(new LogEventHandler($reporter, Logger::INFO));
 
         $logger->debug('Test debug message', ['some' => 'data']);
         $logger->warning('Test warning message', ['some' => 'data']);


### PR DESCRIPTION
## Status
**READY**

## Description
The "Run unit tests" was disabled because it didn't run for 60 days. I have enabled it and it started failing.
This PR:
- reverts to the deprecated usage of logger levels for wider support.
- reverts to reading $record values from array
