### PR TITLE
fix: check if api key is set in Honeybadger::event

### DIFF
--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -216,7 +216,7 @@ class Honeybadger implements Reporter
      */
     public function event($eventTypeOrPayload, array $payload = null): void
     {
-        if (!$this->config['events']['enabled']) {
+        if (empty($this->config['api_key']) || ! $this->config['events']['enabled']) {
             return;
         }
 

--- a/tests/LogEventHandlerTest.php
+++ b/tests/LogEventHandlerTest.php
@@ -30,6 +30,7 @@ class LogEventHandlerTest extends TestCase
     {
         $client = $this->createMock(HoneybadgerClient::class);
         $config = new Config([
+            'api_key' => '1234',
             'events' => [
                 'enabled' => true
             ]
@@ -68,6 +69,7 @@ class LogEventHandlerTest extends TestCase
     {
         $client = $this->createMock(HoneybadgerClient::class);
         $config = new Config([
+            'api_key' => '1234',
             'events' => [
                 'enabled' => true
             ]


### PR DESCRIPTION
## Status
**READY**

## Description
If the API key is not set, there is no point in trying to making the HTTP call.

