### PR TITLE
fix: use RFC3339 extended date format

### DIFF
--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -232,13 +232,13 @@ class Honeybadger implements Reporter
         }
 
         $event = array_merge(
-            ['ts' => (new DateTime())->format(DATE_ATOM)],
+            ['ts' => (new DateTime())->format(DATE_RFC3339_EXTENDED)],
             $payload
         );
 
         // if 'ts' is set, we need to make sure it's a string in the correct format
         if ($event['ts'] instanceof DateTime) {
-            $event['ts'] = $event['ts']->format(DATE_ATOM);
+            $event['ts'] = $event['ts']->format(DATE_RFC3339_EXTENDED);
         }
 
         $this->events->addEvent($event);

--- a/src/LogEventHandler.php
+++ b/src/LogEventHandler.php
@@ -45,7 +45,7 @@ class LogEventHandler extends AbstractProcessingHandler
      */
     protected function getEventPayloadFromMonologRecord($record): array {
         $payload = [
-            'ts' => $record['datetime']->format(DATE_ATOM),
+            'ts' => $record['datetime']->format(DATE_RFC3339_EXTENDED),
             'severity' => strtolower($record['level_name']),
             'message' => $record['message'],
             'channel' => $record['channel'],

--- a/tests/BulkEventDispatcherTest.php
+++ b/tests/BulkEventDispatcherTest.php
@@ -28,7 +28,7 @@ class BulkEventDispatcherTest extends TestCase {
         ]);
         $hbMock = $this->createMock(HoneybadgerClient::class);
         $dispatcher = new BulkEventDispatcher($config, $hbMock);
-        $dispatcher->addEvent(['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_ATOM)]);
+        $dispatcher->addEvent(['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_RFC3339_EXTENDED)]);
         $this->assertTrue($dispatcher->hasEvents());
     }
 
@@ -42,8 +42,8 @@ class BulkEventDispatcherTest extends TestCase {
             ]
         ]);
         $events = [
-            ['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_ATOM), 'message' => 'test 1'],
-            ['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_ATOM), 'message' => 'test 2'],
+            ['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_RFC3339_EXTENDED), 'message' => 'test 1'],
+            ['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_RFC3339_EXTENDED), 'message' => 'test 2'],
         ];
         $hbMock = $this->createMock(HoneybadgerClient::class);
         $hbMock->expects($this->once())->method('events')->with($events);
@@ -64,8 +64,8 @@ class BulkEventDispatcherTest extends TestCase {
             ]
         ]);
         $events = [
-            ['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_ATOM), 'message' => 'test 1'],
-            ['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_ATOM), 'message' => 'test 2'],
+            ['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_RFC3339_EXTENDED), 'message' => 'test 1'],
+            ['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_RFC3339_EXTENDED), 'message' => 'test 2'],
         ];
         $hbMock = $this->createMock(HoneybadgerClient::class);
         $hbMock->expects($this->once())->method('events')->with($events);
@@ -87,8 +87,8 @@ class BulkEventDispatcherTest extends TestCase {
             ]
         ]);
         $events = [
-            ['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_ATOM), 'message' => 'test 1'],
-            ['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_ATOM), 'message' => 'test 2'],
+            ['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_RFC3339_EXTENDED), 'message' => 'test 1'],
+            ['event_type' => 'log', 'ts' => (new DateTime())->format(DATE_RFC3339_EXTENDED), 'message' => 'test 2'],
         ];
         $hbMock = $this->createMock(HoneybadgerClient::class);
         $hbMock->expects($this->once())->method('events')->with($events);

--- a/tests/HoneybadgerClientTest.php
+++ b/tests/HoneybadgerClientTest.php
@@ -58,7 +58,7 @@ class HoneybadgerClientTest extends TestCase
         $events = [
             [
                 'event_type' => 'log',
-                'ts' => (new DateTime())->format(DATE_ATOM),
+                'ts' => (new DateTime())->format(DATE_RFC3339_EXTENDED),
                 'message' => 'Test message'
             ]
         ];

--- a/tests/HoneybadgerTest.php
+++ b/tests/HoneybadgerTest.php
@@ -924,7 +924,7 @@ class HoneybadgerTest extends TestCase
             ->method('addEvent')
             ->with([
                 'event_type' => 'log',
-                'ts' => (new DateTime())->format(DATE_ATOM),
+                'ts' => (new DateTime())->format(DATE_RFC3339_EXTENDED),
                 'message' => 'Test message',
             ]);
 
@@ -948,7 +948,7 @@ class HoneybadgerTest extends TestCase
             ->expects($this->once())
             ->method('addEvent')
             ->with([
-                'ts' => (new DateTime())->format(DATE_ATOM),
+                'ts' => (new DateTime())->format(DATE_RFC3339_EXTENDED),
                 'message' => 'Test message',
             ]);
 

--- a/tests/LogEventHandlerTest.php
+++ b/tests/LogEventHandlerTest.php
@@ -54,14 +54,15 @@ class LogEventHandlerTest extends TestCase
 
         $logger->info('Test log message', ['some' => 'data']);
 
-        $this->assertEquals([[
-            'event_type' => 'log',
-            'ts' => (new \DateTime())->format(DATE_RFC3339_EXTENDED),
-            'channel' => 'test-logger',
-            'message' => 'Test log message',
-            'severity' => 'info',
-            'some' => 'data',
-        ]], $eventsDispatcher->events);
+        $this->assertCount(1, $eventsDispatcher->events);
+
+        $event = $eventsDispatcher->events[0];
+        $this->assertArrayHasKey('ts', $event);
+        $this->assertEquals('log', $event['event_type']);
+        $this->assertEquals('test-logger', $event['channel']);
+        $this->assertEquals('Test log message', $event['message']);
+        $this->assertEquals('info', $event['severity']);
+        $this->assertEquals('data', $event['some']);
     }
 
     /** @test */
@@ -94,13 +95,14 @@ class LogEventHandlerTest extends TestCase
         $logger->debug('Test debug message', ['some' => 'data']);
         $logger->warning('Test warning message', ['some' => 'data']);
 
-        $this->assertEquals([[
-            'event_type' => 'log',
-            'ts' => (new \DateTime())->format(DATE_RFC3339_EXTENDED),
-            'channel' => 'test-logger',
-            'message' => 'Test warning message',
-            'severity' => 'warning',
-            'some' => 'data',
-        ]], $eventsDispatcher->events);
+        $this->assertCount(1, $eventsDispatcher->events);
+
+        $event = $eventsDispatcher->events[0];
+        $this->assertArrayHasKey('ts', $event);
+        $this->assertEquals('log', $event['event_type']);
+        $this->assertEquals('test-logger', $event['channel']);
+        $this->assertEquals('Test warning message', $event['message']);
+        $this->assertEquals('warning', $event['severity']);
+        $this->assertEquals('data', $event['some']);
     }
 }

--- a/tests/LogEventHandlerTest.php
+++ b/tests/LogEventHandlerTest.php
@@ -56,7 +56,7 @@ class LogEventHandlerTest extends TestCase
 
         $this->assertEquals([[
             'event_type' => 'log',
-            'ts' => (new \DateTime())->format(DATE_ATOM),
+            'ts' => (new \DateTime())->format(DATE_RFC3339_EXTENDED),
             'channel' => 'test-logger',
             'message' => 'Test log message',
             'severity' => 'info',
@@ -96,7 +96,7 @@ class LogEventHandlerTest extends TestCase
 
         $this->assertEquals([[
             'event_type' => 'log',
-            'ts' => (new \DateTime())->format(DATE_ATOM),
+            'ts' => (new \DateTime())->format(DATE_RFC3339_EXTENDED),
             'channel' => 'test-logger',
             'message' => 'Test warning message',
             'severity' => 'warning',


### PR DESCRIPTION
Timestamps should be sent with microsecond precision.


