### PR TITLE
feat: send user agent in http clients

### DIFF
--- a/src/CheckInsClient.php
+++ b/src/CheckInsClient.php
@@ -192,7 +192,7 @@ class CheckInsClient extends ApiClient
                 $this->config['personal_auth_token'], ''
             ],
             RequestOptions::HEADERS => [
-                'User-Agent' => 'Honeybadger PHP ' . Honeybadger::VERSION . '; ' . PHP_VERSION,
+                'User-Agent' => $this->config['notifier']['name'] . $this->config['notifier']['version'] . '; ' . PHP_VERSION,
             ],
         ]);
     }

--- a/src/CheckInsClient.php
+++ b/src/CheckInsClient.php
@@ -191,6 +191,9 @@ class CheckInsClient extends ApiClient
             RequestOptions::AUTH => [
                 $this->config['personal_auth_token'], ''
             ],
+            RequestOptions::HEADERS => [
+                'User-Agent' => 'Honeybadger PHP ' . Honeybadger::VERSION . '; ' . PHP_VERSION,
+            ],
         ]);
     }
 }

--- a/src/CheckInsClient.php
+++ b/src/CheckInsClient.php
@@ -192,7 +192,7 @@ class CheckInsClient extends ApiClient
                 $this->config['personal_auth_token'], ''
             ],
             RequestOptions::HEADERS => [
-                'User-Agent' => $this->config['notifier']['name'] . $this->config['notifier']['version'] . '; ' . PHP_VERSION,
+                'User-Agent' => $this->getUserAgent(),
             ],
         ]);
     }

--- a/src/Contracts/ApiClient.php
+++ b/src/Contracts/ApiClient.php
@@ -43,4 +43,14 @@ abstract class ApiClient {
         return !empty($this->config['personal_auth_token']);
     }
 
+    public function getUserAgent(): string
+    {
+        $userAgent = 'Honeybadger PHP; ' . PHP_VERSION;
+        if (isset($this->config['notifier'], $this->config['notifier']['name'], $this->config['notifier']['version'])) {
+            $userAgent = $this->config['notifier']['name'] . ' ' . $this->config['notifier']['version'] . '; ' . PHP_VERSION;
+        }
+
+        return $userAgent;
+    }
+
 }

--- a/src/HoneybadgerClient.php
+++ b/src/HoneybadgerClient.php
@@ -95,6 +95,10 @@ class HoneybadgerClient extends ApiClient
 
     public function makeClient(): Client
     {
+        $userAgent = 'Honeybadger PHP; ' . PHP_VERSION;
+        if (isset($this->config['notifier'], $this->config['notifier']['name'], $this->config['notifier']['version'])) {
+            $userAgent = $this->config['notifier']['name'] . ' ' . $this->config['notifier']['version'] . '; ' . PHP_VERSION;
+        }
         return new Client([
             'base_uri' => $this->config['endpoint'],
             RequestOptions::HTTP_ERRORS => false,
@@ -102,7 +106,7 @@ class HoneybadgerClient extends ApiClient
                 'X-API-Key' => $this->config['api_key'],
                 'Accept' => 'application/json',
                 'Content-Type' => 'application/json',
-                'User-Agent' => $this->config['notifier']['name'] . $this->config['notifier']['version'] . '; ' . PHP_VERSION,
+                'User-Agent' => $userAgent,
             ],
             RequestOptions::TIMEOUT => $this->config['client']['timeout'],
             RequestOptions::PROXY => $this->config['client']['proxy'],

--- a/src/HoneybadgerClient.php
+++ b/src/HoneybadgerClient.php
@@ -95,10 +95,7 @@ class HoneybadgerClient extends ApiClient
 
     public function makeClient(): Client
     {
-        $userAgent = 'Honeybadger PHP; ' . PHP_VERSION;
-        if (isset($this->config['notifier'], $this->config['notifier']['name'], $this->config['notifier']['version'])) {
-            $userAgent = $this->config['notifier']['name'] . ' ' . $this->config['notifier']['version'] . '; ' . PHP_VERSION;
-        }
+
         return new Client([
             'base_uri' => $this->config['endpoint'],
             RequestOptions::HTTP_ERRORS => false,
@@ -106,7 +103,7 @@ class HoneybadgerClient extends ApiClient
                 'X-API-Key' => $this->config['api_key'],
                 'Accept' => 'application/json',
                 'Content-Type' => 'application/json',
-                'User-Agent' => $userAgent,
+                'User-Agent' => $this->getUserAgent(),
             ],
             RequestOptions::TIMEOUT => $this->config['client']['timeout'],
             RequestOptions::PROXY => $this->config['client']['proxy'],

--- a/src/HoneybadgerClient.php
+++ b/src/HoneybadgerClient.php
@@ -102,7 +102,7 @@ class HoneybadgerClient extends ApiClient
                 'X-API-Key' => $this->config['api_key'],
                 'Accept' => 'application/json',
                 'Content-Type' => 'application/json',
-                'User-Agent' => 'Honeybadger PHP ' . Honeybadger::VERSION . '; ' . PHP_VERSION,
+                'User-Agent' => $this->config['notifier']['name'] . $this->config['notifier']['version'] . '; ' . PHP_VERSION,
             ],
             RequestOptions::TIMEOUT => $this->config['client']['timeout'],
             RequestOptions::PROXY => $this->config['client']['proxy'],

--- a/src/HoneybadgerClient.php
+++ b/src/HoneybadgerClient.php
@@ -102,6 +102,7 @@ class HoneybadgerClient extends ApiClient
                 'X-API-Key' => $this->config['api_key'],
                 'Accept' => 'application/json',
                 'Content-Type' => 'application/json',
+                'User-Agent' => 'Honeybadger PHP ' . Honeybadger::VERSION . '; ' . PHP_VERSION,
             ],
             RequestOptions::TIMEOUT => $this->config['client']['timeout'],
             RequestOptions::PROXY => $this->config['client']['proxy'],


### PR DESCRIPTION
## Status
**READY**

## Description
Sends a `User-Agent` header along with HTTP requests.
The header is made up from the `notifier` config. This way it can be configured to have a different value when being setup from the `honeybadger-laravel` package.
An example value could be:
```
honeybadger-php 2.20.0; 5.3.6-13ubuntu3.2
```
