### PR TITLE
feat: ignore breadcrumbs with empty message

### DIFF
--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -201,7 +201,7 @@ class Honeybadger implements Reporter
 
     public function addBreadcrumb(string $message, array $metadata = [], string $category = 'custom'): Reporter
     {
-        if ($this->config['breadcrumbs']['enabled']) {
+        if ($this->config['breadcrumbs']['enabled'] && !empty($message)) {
             $this->breadcrumbs->add([
                 'message' => $message,
                 'metadata' => $metadata,


### PR DESCRIPTION
## Status
**READY**

## Description

Skips breadcrumbs that have empty message.