### PR TITLE
perf: update honeybadger-php to play nice with PHP 8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file. See [Keep a
 CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.22.1 (2024-11-22)
+
+
+### Fixed
+
+* add PHP 8.4 compatibility
+
 ## [2.22.0](https://github.com/honeybadger-io/honeybadger-php/compare/v2.21.0...v2.22.0) (2024-11-16)
 
 

--- a/src/CheckInsClientWithErrorHandling.php
+++ b/src/CheckInsClientWithErrorHandling.php
@@ -18,7 +18,7 @@ class CheckInsClientWithErrorHandling
      */
     private $baseClient;
 
-    public function __construct(Config $config, Client $httpClient = null)
+    public function __construct(Config $config, ?Client $httpClient = null)
     {
         $this->config = $config;
         $this->baseClient = new CheckInsClient($config, $httpClient);

--- a/src/CheckInsManager.php
+++ b/src/CheckInsManager.php
@@ -24,7 +24,7 @@ class CheckInsManager implements SyncCheckIns {
      * @param array $config
      * @param CheckInsClient|null $client
      */
-    public function __construct(array $config, CheckInsClient $client = null) {
+    public function __construct(array $config, ?CheckInsClient $client = null) {
         $this->config = new Config($config);
         $this->client = $client ?? new CheckInsClient($this->config);
     }

--- a/src/Contracts/ApiClient.php
+++ b/src/Contracts/ApiClient.php
@@ -20,9 +20,9 @@ abstract class ApiClient {
 
     /**
      * @param Config $config
-     * @param Client|null $httpClient
+     * @param ?Client $httpClient
      */
-    public function __construct(Config $config, Client $httpClient = null) {
+    public function __construct(Config $config, ?Client $httpClient = null) {
         $this->config = $config;
         $this->client = $httpClient ?? $this->makeClient();
     }

--- a/src/Contracts/Reporter.php
+++ b/src/Contracts/Reporter.php
@@ -9,13 +9,13 @@ interface Reporter
 {
     /**
      * @param  \Throwable  $throwable
-     * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @param  ?\Symfony\Component\HttpFoundation\Request  $request
      * @param  array  $additionalParams
      * @return array
      *
      * @throws \Honeybadger\Exceptions\ServiceException
      */
-    public function notify(Throwable $throwable, FoundationRequest $request = null, array $additionalParams = []): array;
+    public function notify(Throwable $throwable, ?FoundationRequest $request = null, array $additionalParams = []): array;
 
     /**
      * @param  array  $payload
@@ -89,7 +89,7 @@ interface Reporter
      *
      * @return void
      */
-    public function event($eventTypeOrPayload, array $payload = null): void;
+    public function event($eventTypeOrPayload, ?array $payload = null): void;
 
     /**
      * Flush all events from the queue.

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -52,7 +52,7 @@ class Environment
      */
     protected $server = [];
 
-    public function __construct(array $server = null, array $env = null)
+    public function __construct(?array $server = null, ?array $env = null)
     {
         $this->server = array_merge(
             $server ?? $_SERVER,

--- a/src/ExceptionNotification.php
+++ b/src/ExceptionNotification.php
@@ -65,11 +65,11 @@ class ExceptionNotification
 
     /**
      * @param  \Throwable  $e
-     * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @param  ?\Symfony\Component\HttpFoundation\Request  $request
      * @param  array  $additionalParams
      * @return array
      */
-    public function make(Throwable $e, FoundationRequest $request = null, array $additionalParams = []): array
+    public function make(Throwable $e, ?FoundationRequest $request = null, array $additionalParams = []): array
     {
         $this->throwable = $e;
         $this->backtrace = $this->makeBacktrace();
@@ -138,10 +138,10 @@ class ExceptionNotification
     }
 
     /**
-     * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @param  ?\Symfony\Component\HttpFoundation\Request  $request
      * @return \Honeybadger\Request
      */
-    private function makeRequest(FoundationRequest $request = null): Request
+    private function makeRequest(?FoundationRequest $request = null): Request
     {
         return (new Request($request))
             ->filterKeys($this->config['request']['filter']);

--- a/src/Exceptions/ServiceException.php
+++ b/src/Exceptions/ServiceException.php
@@ -60,7 +60,7 @@ class ServiceException extends Exception
      * @param Throwable|null $e
      * @return self
      */
-    public static function generic(Throwable $e = null): self
+    public static function generic(?Throwable $e = null): self
     {
         $message = $e
             ? 'There was an error sending the payload to Honeybadger: '.$e->getMessage()

--- a/src/Handlers/ErrorHandler.php
+++ b/src/Handlers/ErrorHandler.php
@@ -32,7 +32,7 @@ class ErrorHandler extends Handler implements HandlerContract
         $this->previousHandler = set_error_handler([$this, 'handle']);
     }
 
-    public function handle(int $level, string $error, string $file = null, ?int $line = null)
+    public function handle(int $level, string $error, ?string $file = null, ?int $line = null)
     {
         // When the @ operator is used, it temporarily changes `error_reporting()`'s return value
         // to reflect what error types should be reported. This means we should get 0 (no errors).

--- a/src/Handlers/ErrorHandler.php
+++ b/src/Handlers/ErrorHandler.php
@@ -32,7 +32,7 @@ class ErrorHandler extends Handler implements HandlerContract
         $this->previousHandler = set_error_handler([$this, 'handle']);
     }
 
-    public function handle(int $level, string $error, string $file = null, int $line = null)
+    public function handle(int $level, string $error, string $file = null, ?int $line = null)
     {
         // When the @ operator is used, it temporarily changes `error_reporting()`'s return value
         // to reflect what error types should be reported. This means we should get 0 (no errors).

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -68,7 +68,7 @@ class Honeybadger implements Reporter
      */
     protected $events;
 
-    public function __construct(array $config = [], Client $client = null, BulkEventDispatcher $eventsDispatcher = null)
+    public function __construct(array $config = [], ?Client $client = null, ?BulkEventDispatcher $eventsDispatcher = null)
     {
         $this->config = new Config($config);
 
@@ -84,7 +84,7 @@ class Honeybadger implements Reporter
     /**
      * {@inheritdoc}
      */
-    public function notify(Throwable $throwable, FoundationRequest $request = null, array $additionalParams = []): array
+    public function notify(Throwable $throwable, ?FoundationRequest $request = null, array $additionalParams = []): array
     {
         if (! $this->shouldReport($throwable)) {
             return [];
@@ -223,7 +223,7 @@ class Honeybadger implements Reporter
     /**
      * {@inheritdoc}
      */
-    public function event($eventTypeOrPayload, array $payload = null): void
+    public function event($eventTypeOrPayload, ?array $payload = null): void
     {
         if (empty($this->config['api_key']) || ! $this->config['events']['enabled']) {
             return;

--- a/src/Request.php
+++ b/src/Request.php
@@ -15,10 +15,10 @@ class Request
     protected $request;
 
     /**
-     * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @param  ?\Symfony\Component\HttpFoundation\Request  $request
      * @param  array  $options
      */
-    public function __construct(FoundationRequest $request = null)
+    public function __construct(?FoundationRequest $request = null)
     {
         $this->request = $request ?? FoundationRequest::createFromGlobals();
 

--- a/tests/BacktraceFactoryTest.php
+++ b/tests/BacktraceFactoryTest.php
@@ -62,7 +62,7 @@ class BacktraceFactoryTest extends TestCase
     }
 
     /** @test */
-    public function bactraces_send_class()
+    public function backtraces_send_class()
     {
         try {
             throw new Exception('test');
@@ -74,7 +74,7 @@ class BacktraceFactoryTest extends TestCase
     }
 
     /** @test */
-    public function bactraces_send_type()
+    public function backtraces_send_type()
     {
         try {
             throw new Exception('test');


### PR DESCRIPTION
## Status
WIP
2 tests are currently failing under PHP 8.4
I'm not really sure why.

## Description
Make the repo PHP 8.4 play nice with PHP 8.4 and remove deprecation warning like these:

```
Deprecated: Honeybadger\Honeybadger::__construct(): Implicitly marking parameter $client as nullable is deprecated, the explicit nullable type must be used instead in /Users/julian/Development/laravel/fax/vendor/honeybadger-io/honeybadger-php/src/Honeybadger.php on line 71
```


## Related PRs
None

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog Entry (unreleased)
