### PR TITLE
perf: add PHP 8.4 to test matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         composer-flags: ["--prefer-stable", "--prefer-lowest"]
-        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.4']
         exclude:
           - {php-versions: '8.1', composer-flags: "--prefer-lowest"}
           - {php-versions: '8.2', composer-flags: "--prefer-lowest"}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,6 +16,7 @@ jobs:
         exclude:
           - {php-versions: '8.1', composer-flags: "--prefer-lowest"}
           - {php-versions: '8.2', composer-flags: "--prefer-lowest"}
+          - {php-versions: '8.4', composer-flags: "--prefer-lowest"}
     name: PHP ${{ matrix.php-versions }} Tests (${{ matrix.composer-flags }})
     steps:
     - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,6 @@ All notable changes to this project will be documented in this file. See [Keep a
 CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.22.1 (2024-11-22)
-
-
-### Fixed
-
-* add PHP 8.4 compatibility
-
 ## [2.22.0](https://github.com/honeybadger-io/honeybadger-php/compare/v2.21.0...v2.22.0) (2024-11-16)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file. See [Keep a
 CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.22.1 (2024-11-22)
+
+
+### Fixed
+
+* add PHP 8.4 compatibility
+
 ## [2.22.0](https://github.com/honeybadger-io/honeybadger-php/compare/v2.21.0...v2.22.0) (2024-11-16)
 
 

--- a/src/CheckInsClientWithErrorHandling.php
+++ b/src/CheckInsClientWithErrorHandling.php
@@ -18,7 +18,7 @@ class CheckInsClientWithErrorHandling
      */
     private $baseClient;
 
-    public function __construct(Config $config, Client $httpClient = null)
+    public function __construct(Config $config, ?Client $httpClient = null)
     {
         $this->config = $config;
         $this->baseClient = new CheckInsClient($config, $httpClient);

--- a/src/CheckInsManager.php
+++ b/src/CheckInsManager.php
@@ -24,7 +24,7 @@ class CheckInsManager implements SyncCheckIns {
      * @param array $config
      * @param CheckInsClient|null $client
      */
-    public function __construct(array $config, CheckInsClient $client = null) {
+    public function __construct(array $config, ?CheckInsClient $client = null) {
         $this->config = new Config($config);
         $this->client = $client ?? new CheckInsClient($this->config);
     }

--- a/src/Contracts/ApiClient.php
+++ b/src/Contracts/ApiClient.php
@@ -20,9 +20,9 @@ abstract class ApiClient {
 
     /**
      * @param Config $config
-     * @param Client|null $httpClient
+     * @param ?Client $httpClient
      */
-    public function __construct(Config $config, Client $httpClient = null) {
+    public function __construct(Config $config, ?Client $httpClient = null) {
         $this->config = $config;
         $this->client = $httpClient ?? $this->makeClient();
     }

--- a/src/Contracts/Reporter.php
+++ b/src/Contracts/Reporter.php
@@ -9,13 +9,13 @@ interface Reporter
 {
     /**
      * @param  \Throwable  $throwable
-     * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @param  ?\Symfony\Component\HttpFoundation\Request  $request
      * @param  array  $additionalParams
      * @return array
      *
      * @throws \Honeybadger\Exceptions\ServiceException
      */
-    public function notify(Throwable $throwable, FoundationRequest $request = null, array $additionalParams = []): array;
+    public function notify(Throwable $throwable, ?FoundationRequest $request = null, array $additionalParams = []): array;
 
     /**
      * @param  array  $payload
@@ -89,7 +89,7 @@ interface Reporter
      *
      * @return void
      */
-    public function event($eventTypeOrPayload, array $payload = null): void;
+    public function event($eventTypeOrPayload, ?array $payload = null): void;
 
     /**
      * Flush all events from the queue.

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -52,7 +52,7 @@ class Environment
      */
     protected $server = [];
 
-    public function __construct(array $server = null, array $env = null)
+    public function __construct(?array $server = null, ?array $env = null)
     {
         $this->server = array_merge(
             $server ?? $_SERVER,

--- a/src/ExceptionNotification.php
+++ b/src/ExceptionNotification.php
@@ -65,11 +65,11 @@ class ExceptionNotification
 
     /**
      * @param  \Throwable  $e
-     * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @param  ?\Symfony\Component\HttpFoundation\Request  $request
      * @param  array  $additionalParams
      * @return array
      */
-    public function make(Throwable $e, FoundationRequest $request = null, array $additionalParams = []): array
+    public function make(Throwable $e, ?FoundationRequest $request = null, array $additionalParams = []): array
     {
         $this->throwable = $e;
         $this->backtrace = $this->makeBacktrace();
@@ -138,10 +138,10 @@ class ExceptionNotification
     }
 
     /**
-     * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @param  ?\Symfony\Component\HttpFoundation\Request  $request
      * @return \Honeybadger\Request
      */
-    private function makeRequest(FoundationRequest $request = null): Request
+    private function makeRequest(?FoundationRequest $request = null): Request
     {
         return (new Request($request))
             ->filterKeys($this->config['request']['filter']);

--- a/src/Exceptions/ServiceException.php
+++ b/src/Exceptions/ServiceException.php
@@ -60,7 +60,7 @@ class ServiceException extends Exception
      * @param Throwable|null $e
      * @return self
      */
-    public static function generic(Throwable $e = null): self
+    public static function generic(?Throwable $e = null): self
     {
         $message = $e
             ? 'There was an error sending the payload to Honeybadger: '.$e->getMessage()

--- a/src/Handlers/ErrorHandler.php
+++ b/src/Handlers/ErrorHandler.php
@@ -32,7 +32,7 @@ class ErrorHandler extends Handler implements HandlerContract
         $this->previousHandler = set_error_handler([$this, 'handle']);
     }
 
-    public function handle(int $level, string $error, string $file = null, ?int $line = null)
+    public function handle(int $level, string $error, ?string $file = null, ?int $line = null)
     {
         // When the @ operator is used, it temporarily changes `error_reporting()`'s return value
         // to reflect what error types should be reported. This means we should get 0 (no errors).

--- a/src/Handlers/ErrorHandler.php
+++ b/src/Handlers/ErrorHandler.php
@@ -32,7 +32,7 @@ class ErrorHandler extends Handler implements HandlerContract
         $this->previousHandler = set_error_handler([$this, 'handle']);
     }
 
-    public function handle(int $level, string $error, string $file = null, int $line = null)
+    public function handle(int $level, string $error, string $file = null, ?int $line = null)
     {
         // When the @ operator is used, it temporarily changes `error_reporting()`'s return value
         // to reflect what error types should be reported. This means we should get 0 (no errors).

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -68,7 +68,7 @@ class Honeybadger implements Reporter
      */
     protected $events;
 
-    public function __construct(array $config = [], Client $client = null, BulkEventDispatcher $eventsDispatcher = null)
+    public function __construct(array $config = [], ?Client $client = null, ?BulkEventDispatcher $eventsDispatcher = null)
     {
         $this->config = new Config($config);
 
@@ -84,7 +84,7 @@ class Honeybadger implements Reporter
     /**
      * {@inheritdoc}
      */
-    public function notify(Throwable $throwable, FoundationRequest $request = null, array $additionalParams = []): array
+    public function notify(Throwable $throwable, ?FoundationRequest $request = null, array $additionalParams = []): array
     {
         if (! $this->shouldReport($throwable)) {
             return [];
@@ -223,7 +223,7 @@ class Honeybadger implements Reporter
     /**
      * {@inheritdoc}
      */
-    public function event($eventTypeOrPayload, array $payload = null): void
+    public function event($eventTypeOrPayload, ?array $payload = null): void
     {
         if (empty($this->config['api_key']) || ! $this->config['events']['enabled']) {
             return;

--- a/src/Request.php
+++ b/src/Request.php
@@ -15,10 +15,10 @@ class Request
     protected $request;
 
     /**
-     * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @param  ?\Symfony\Component\HttpFoundation\Request  $request
      * @param  array  $options
      */
-    public function __construct(FoundationRequest $request = null)
+    public function __construct(?FoundationRequest $request = null)
     {
         $this->request = $request ?? FoundationRequest::createFromGlobals();
 

--- a/tests/BacktraceFactoryTest.php
+++ b/tests/BacktraceFactoryTest.php
@@ -40,7 +40,12 @@ class BacktraceFactoryTest extends TestCase
             $backtrace = (new BacktraceFactory($e, new Config))->trace();
         }
 
-        $this->assertEquals('Honeybadger\Tests\{closure}', $backtrace[0]['method']);
+        // if php version is 8.4.0 or higher, then we need to check for a more specific closure name
+        if (version_compare(PHP_VERSION, '8.4.0', '>=')) {
+            $this->assertEquals('{closure:Honeybadger\Tests\BacktraceFactoryTest::it_correctly_formats_annonymous_functions():33}', $backtrace[0]['method']);
+        } else {
+            $this->assertEquals('Honeybadger\Tests\{closure}', $backtrace[0]['method']);
+        }
         $this->assertEquals(['bar'], $backtrace[0]['args']);
     }
 
@@ -153,7 +158,12 @@ class BacktraceFactoryTest extends TestCase
             $backtrace = (new BacktraceFactory($e, new Config))->trace();
         }
 
-        $this->assertEquals('Honeybadger\Tests\{closure}', $backtrace[0]['method']);
+        // if php version is 8.4.0 or higher, then we need to check for a more specific closure name
+        if (version_compare(PHP_VERSION, '8.4.0', '>=')) {
+            $this->assertEquals('{closure:Honeybadger\Tests\BacktraceFactoryTest::args_with_object_should_be_literals():151}', $backtrace[0]['method']);
+        } else {
+            $this->assertEquals('Honeybadger\Tests\{closure}', $backtrace[0]['method']);
+        }
         $this->assertEquals(['bar', '[LITERAL]Object('.TestClass::class.')'], $backtrace[0]['args']);
     }
 }

--- a/tests/BacktraceFactoryTest.php
+++ b/tests/BacktraceFactoryTest.php
@@ -62,7 +62,7 @@ class BacktraceFactoryTest extends TestCase
     }
 
     /** @test */
-    public function bactraces_send_class()
+    public function backtraces_send_class()
     {
         try {
             throw new Exception('test');
@@ -74,7 +74,7 @@ class BacktraceFactoryTest extends TestCase
     }
 
     /** @test */
-    public function bactraces_send_type()
+    public function backtraces_send_type()
     {
         try {
             throw new Exception('test');


### PR DESCRIPTION
## Status
**READY**

## Description
This is a fork from https://github.com/the-pulli/honeybadger-php/tree/php-84, which I used to fix the failing tests. The failing tests are because PHP 8.4 introduced better [tracing information for closures](https://tideways.com/profiler/blog/php-8-4-improves-closure-naming-for-simplified-debugging).

Note: I have all debugging information enabled on my local env and I'm getting many deprecated warnings (from guzzle and phpunit). It seems that those have not been addressed yet by the community.
