### PR TITLE
fix(checkins): read error message from response body

### DIFF
--- a/src/Exceptions/ServiceException.php
+++ b/src/Exceptions/ServiceException.php
@@ -85,4 +85,13 @@ class ServiceException extends Exception
     {
         return new static("Missing personal auth token. This token is required to use Honeybadger's Data APIs.");
     }
+
+    /**
+     * @param string $message
+     * @return self
+     */
+    public static function withMessage(string $message): self
+    {
+        return new static($message);
+    }
 }

--- a/src/Exceptions/ServiceExceptionFactory.php
+++ b/src/Exceptions/ServiceExceptionFactory.php
@@ -27,6 +27,14 @@ class ServiceExceptionFactory
 
     private function exception(bool $isFromEventsApi = false): ServiceException
     {
+        $message = $this->response->getBody()->getContents();
+        if (!empty($message)) {
+            $data = json_decode($message, true);
+            if (isset($data['errors'])) {
+                return ServiceException::withMessage($data['errors']);
+            }
+        }
+
         if ($this->response->getStatusCode() === Response::HTTP_FORBIDDEN) {
             return ServiceException::invalidApiKey();
         }

--- a/src/Exceptions/ServiceExceptionFactory.php
+++ b/src/Exceptions/ServiceExceptionFactory.php
@@ -27,12 +27,17 @@ class ServiceExceptionFactory
 
     private function exception(bool $isFromEventsApi = false): ServiceException
     {
-        $message = $this->response->getBody()->getContents();
-        if (!empty($message)) {
-            $data = json_decode($message, true);
-            if (isset($data['errors'])) {
-                return ServiceException::withMessage($data['errors']);
+        try {
+            $message = $this->response->getBody()->getContents();
+            if (!empty($message)) {
+                $data = json_decode($message, true);
+                if (isset($data['errors'])) {
+                    return ServiceException::withMessage($data['errors']);
+                }
             }
+        } catch (\Exception $e) {
+            // Do nothing
+            // Fallback to default error messages based on status code
         }
 
         if ($this->response->getStatusCode() === Response::HTTP_FORBIDDEN) {


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes #223.
Read error messages from response body instead of relying only on the HTTP status code.

This should handle the cases where a more specific message is included in the response body.
For example, we would show a generic _The API key provided is invalid._ when receiving a 403, but there are cases where the message could be:
- either _You need to upgrade your plan to get cron support._
- or _You have reached your plan's limit for the number of check-ins._

