### PR TITLE
feat: add Insights event sampling

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -80,7 +80,8 @@ class Config extends Repository
             'events' => [
                 'enabled' => false,
                 'bulk_threshold' => BulkEventDispatcher::BULK_THRESHOLD,
-                'dispatch_interval_seconds' => BulkEventDispatcher::DISPATCH_INTERVAL_SECONDS
+                'dispatch_interval_seconds' => BulkEventDispatcher::DISPATCH_INTERVAL_SECONDS,
+                'sample_rate' => 100
             ],
         ], $config);
 

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -269,6 +269,16 @@ class Honeybadger implements Reporter
             return;
         }
 
+        // Apply sampling after before_event callbacks
+        if (!$this->shouldSampleEvent($event)) {
+            return;
+        }
+
+        // Remove internal metadata before sending
+        if (isset($event['_hb'])) {
+            unset($event['_hb']);
+        }
+
         $this->events->addEvent($event);
     }
 
@@ -379,5 +389,42 @@ class Honeybadger implements Reporter
         $this->context('honeybadger_action', $action);
 
         return $this;
+    }
+
+    /**
+     * Determines if an event should be sampled based on sampling rate configuration
+     * and any override in the event payload.
+     *
+     * @param array $event The event payload
+     * @return bool Whether the event should be sent
+     */
+    protected function shouldSampleEvent(array $event): bool
+    {
+        // Get the configured sampling rate (0-100)
+        $samplingRate = $this->config['events']['sample_rate'] ?? 100;
+
+        // Check for override in event payload
+        if (isset($event['_hb']['sample_rate']) && is_numeric($event['_hb']['sample_rate'])) {
+            $samplingRate = (int) $event['_hb']['sample_rate'];
+        }
+
+        // If sampling rate is 0, don't send any events
+        if ($samplingRate <= 0) {
+            return false;
+        }
+
+        // If sampling rate is 100 or greater, send all events
+        if ($samplingRate >= 100) {
+            return true;
+        }
+
+        // If requestId is present, use it for consistent sampling
+        if (isset($event['requestId'])) {
+            // Use CRC32 of requestId for consistent sampling
+            return crc32((string) $event['requestId']) % 100 < $samplingRate;
+        }
+
+        // Otherwise, use random sampling
+        return mt_rand(0, 99) < $samplingRate;
     }
 }

--- a/src/Honeybadger.php
+++ b/src/Honeybadger.php
@@ -420,8 +420,10 @@ class Honeybadger implements Reporter
 
         // If requestId is present, use it for consistent sampling
         if (isset($event['requestId'])) {
-            // Use CRC32 of requestId for consistent sampling
-            return crc32((string) $event['requestId']) % 100 < $samplingRate;
+            // Use CRC32 of requestId for consistent sampling,
+            // and use sprintf to convert to unsigned integer
+            $crc = sprintf('%u', crc32((string) $event['requestId']));
+            return $crc % 100 < $samplingRate;
         }
 
         // Otherwise, use random sampling

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -66,6 +66,7 @@ class ConfigTest extends TestCase
                 'enabled' => false,
                 'bulk_threshold' => 50,
                 'dispatch_interval_seconds' => 2,
+                'sample_rate' => 100,
             ],
         ], $config);
     }
@@ -131,6 +132,7 @@ class ConfigTest extends TestCase
                 'enabled' => false,
                 'bulk_threshold' => 50,
                 'dispatch_interval_seconds' => 2,
+                'sample_rate' => 100,
             ],
         ], $config);
     }

--- a/tests/EventSamplingTest.php
+++ b/tests/EventSamplingTest.php
@@ -1,0 +1,291 @@
+<?php
+
+namespace Honeybadger\Tests;
+
+use Honeybadger\BulkEventDispatcher;
+use Honeybadger\Config;
+use Honeybadger\Honeybadger;
+use PHPUnit\Framework\TestCase;
+
+class EventSamplingTest extends TestCase
+{
+    /** @test */
+    public function it_samples_events_based_on_sample_rate()
+    {
+        // Create a mock client
+        $client = $this->createMock(\Honeybadger\HoneybadgerClient::class);
+
+        // Create a custom event dispatcher that tracks events
+        $eventsDispatcher = new class(new Config([
+            'api_key' => '1234',
+            'events' => [
+                'enabled' => true,
+                'sample_rate' => 0 // No events should be sent
+            ]
+        ]), $client) extends BulkEventDispatcher {
+            public $events = [];
+
+            public function addEvent($event): void
+            {
+                $this->events[] = $event;
+            }
+        };
+
+        // Create Honeybadger instance with 0% sampling rate
+        $badger = new Honeybadger([
+            'api_key' => '1234',
+            'events' => [
+                'enabled' => true,
+                'sample_rate' => 0 // No events should be sent
+            ]
+        ], null, $eventsDispatcher);
+
+        // Send an event
+        $badger->event('log', ['message' => 'Test message']);
+
+        // No events should be in the queue
+        $this->assertCount(0, $eventsDispatcher->events);
+
+        // Now create a new instance with 100% sampling rate
+        $eventsDispatcher = new class(new Config([
+            'api_key' => '1234',
+            'events' => [
+                'enabled' => true,
+                'sample_rate' => 100 // All events should be sent
+            ]
+        ]), $client) extends BulkEventDispatcher {
+            public $events = [];
+
+            public function addEvent($event): void
+            {
+                $this->events[] = $event;
+            }
+        };
+
+        $badger = new Honeybadger([
+            'api_key' => '1234',
+            'events' => [
+                'enabled' => true,
+                'sample_rate' => 100 // All events should be sent
+            ]
+        ], null, $eventsDispatcher);
+
+        // Send an event
+        $badger->event('log', ['message' => 'Test message']);
+
+        // Event should be in the queue
+        $this->assertCount(1, $eventsDispatcher->events);
+    }
+
+    /** @test */
+    public function it_samples_consistently_based_on_requestId()
+    {
+        // Create a mock client
+        $client = $this->createMock(\Honeybadger\HoneybadgerClient::class);
+
+        // Create a custom event dispatcher that tracks events
+        $eventsDispatcher = new class(new Config([
+            'api_key' => '1234',
+            'events' => [
+                'enabled' => true,
+                'sample_rate' => 50 // 50% of events should be sent
+            ]
+        ]), $client) extends BulkEventDispatcher {
+            public $events = [];
+
+            public function addEvent($event): void
+            {
+                $this->events[] = $event;
+            }
+        };
+
+        // Create Honeybadger instance with 50% sampling rate
+        $badger = new Honeybadger([
+            'api_key' => '1234',
+            'events' => [
+                'enabled' => true,
+                'sample_rate' => 50 // 50% of events should be sent
+            ]
+        ], null, $eventsDispatcher);
+
+        // Create a requestId that will be sampled (using a known value that will pass the CRC32 check)
+        $sampledRequestId = 'sampled-request-123';
+
+        // Create a requestId that will not be sampled (using a known value that will fail the CRC32 check)
+        $notSampledRequestId = 'not-sampled-request-456';
+
+        // Verify that all events with the same requestId are consistently sampled
+        // First, send multiple events with the sampled requestId
+        for ($i = 0; $i < 5; $i++) {
+            $badger->event('log', [
+                'message' => "Test message $i",
+                'requestId' => $sampledRequestId
+            ]);
+        }
+
+        // Check if events were sent consistently (either all or none)
+        $sampledCount = count($eventsDispatcher->events);
+        $this->assertTrue($sampledCount === 0 || $sampledCount === 5,
+            "Expected either 0 or 5 events to be sampled, got $sampledCount");
+
+        // Reset the events
+        $eventsDispatcher->events = [];
+
+        // Now send multiple events with the other requestId
+        for ($i = 0; $i < 5; $i++) {
+            $badger->event('log', [
+                'message' => "Test message $i",
+                'requestId' => $notSampledRequestId
+            ]);
+        }
+
+        // Check if events were sent consistently (either all or none)
+        $sampledCount = count($eventsDispatcher->events);
+        $this->assertTrue($sampledCount === 0 || $sampledCount === 5,
+            "Expected either 0 or 5 events to be sampled, got $sampledCount");
+    }
+
+    /** @test */
+    public function it_respects_sample_rate_override_in_event_metadata()
+    {
+        // Create a mock client
+        $client = $this->createMock(\Honeybadger\HoneybadgerClient::class);
+
+        // Create a custom event dispatcher that tracks events
+        $eventsDispatcher = new class(new Config([
+            'api_key' => '1234',
+            'events' => [
+                'enabled' => true,
+                'sample_rate' => 0 // No events should be sent by default
+            ]
+        ]), $client) extends BulkEventDispatcher {
+            public $events = [];
+
+            public function addEvent($event): void
+            {
+                $this->events[] = $event;
+            }
+        };
+
+        // Create Honeybadger instance with 0% sampling rate
+        $badger = new Honeybadger([
+            'api_key' => '1234',
+            'events' => [
+                'enabled' => true,
+                'sample_rate' => 0 // No events should be sent by default
+            ]
+        ], null, $eventsDispatcher);
+
+        // Send an event with no override - should not be sent
+        $badger->event('log', ['message' => 'This event should not be sent']);
+
+        // Send an event with override to 100% - should be sent
+        $badger->event('log', [
+            'message' => 'This event should be sent',
+            '_hb' => ['sample_rate' => 100]
+        ]);
+
+        // Only the second event should be in the queue
+        $this->assertCount(1, $eventsDispatcher->events);
+        $this->assertEquals('This event should be sent', $eventsDispatcher->events[0]['message']);
+    }
+
+    /** @test */
+    public function it_removes_hb_metadata_before_sending_event()
+    {
+        // Create a mock client
+        $client = $this->createMock(\Honeybadger\HoneybadgerClient::class);
+
+        // Create a custom event dispatcher that tracks events
+        $eventsDispatcher = new class(new Config([
+            'api_key' => '1234',
+            'events' => [
+                'enabled' => true,
+                'sample_rate' => 100 // All events should be sent
+            ]
+        ]), $client) extends BulkEventDispatcher {
+            public $events = [];
+
+            public function addEvent($event): void
+            {
+                $this->events[] = $event;
+            }
+        };
+
+        // Create Honeybadger instance
+        $badger = new Honeybadger([
+            'api_key' => '1234',
+            'events' => [
+                'enabled' => true,
+                'sample_rate' => 100
+            ]
+        ], null, $eventsDispatcher);
+
+        // Send an event with _hb metadata
+        $badger->event('log', [
+            'message' => 'Test message',
+            '_hb' => [
+                'sample_rate' => 100,
+                'other_metadata' => 'value'
+            ]
+        ]);
+
+        // Verify the event was sent
+        $this->assertCount(1, $eventsDispatcher->events);
+
+        // Verify the _hb metadata was removed
+        $this->assertArrayNotHasKey('_hb', $eventsDispatcher->events[0]);
+
+        // Verify other fields are still present
+        $this->assertEquals('Test message', $eventsDispatcher->events[0]['message']);
+        $this->assertEquals('log', $eventsDispatcher->events[0]['event_type']);
+    }
+
+    /** @test */
+    public function it_runs_sampling_after_before_event_callbacks()
+    {
+        // Create a mock client
+        $client = $this->createMock(\Honeybadger\HoneybadgerClient::class);
+
+        // Create a custom event dispatcher that tracks events
+        $eventsDispatcher = new class(new Config([
+            'api_key' => '1234',
+            'events' => [
+                'enabled' => true,
+                'sample_rate' => 0 // No events should be sent by default
+            ]
+        ]), $client) extends BulkEventDispatcher {
+            public $events = [];
+
+            public function addEvent($event): void
+            {
+                $this->events[] = $event;
+            }
+        };
+
+        // Create Honeybadger instance with 0% sampling rate
+        $badger = new Honeybadger([
+            'api_key' => '1234',
+            'events' => [
+                'enabled' => true,
+                'sample_rate' => 0 // No events should be sent by default
+            ]
+        ], null, $eventsDispatcher);
+
+        // Register a before_event callback that adds the _hb metadata to override sampling
+        $badger->beforeEvent(function (&$event) {
+            $event['_hb'] = ['sample_rate' => 100]; // Override to always send
+            return true;
+        });
+
+        // Send an event
+        $badger->event('log', ['message' => 'This event should be sent']);
+
+        // The event should be in the queue because the callback added the override
+        $this->assertCount(1, $eventsDispatcher->events);
+        $this->assertEquals('This event should be sent', $eventsDispatcher->events[0]['message']);
+
+        // The _hb metadata should be removed
+        $this->assertArrayNotHasKey('_hb', $eventsDispatcher->events[0]);
+    }
+}

--- a/tests/EventSamplingTest.php
+++ b/tests/EventSamplingTest.php
@@ -10,19 +10,15 @@ use PHPUnit\Framework\TestCase;
 class EventSamplingTest extends TestCase
 {
     /** @test */
-    public function it_samples_events_based_on_sample_rate()
+    public function it_does_not_send_events_when_sample_rate_is_zero()
     {
         // Create a mock client
         $client = $this->createMock(\Honeybadger\HoneybadgerClient::class);
 
+        $config = events_config(0);
+
         // Create a custom event dispatcher that tracks events
-        $eventsDispatcher = new class(new Config([
-            'api_key' => '1234',
-            'events' => [
-                'enabled' => true,
-                'sample_rate' => 0 // No events should be sent
-            ]
-        ]), $client) extends BulkEventDispatcher {
+        $eventsDispatcher = new class(new Config($config), $client) extends BulkEventDispatcher {
             public $events = [];
 
             public function addEvent($event): void
@@ -32,28 +28,25 @@ class EventSamplingTest extends TestCase
         };
 
         // Create Honeybadger instance with 0% sampling rate
-        $badger = new Honeybadger([
-            'api_key' => '1234',
-            'events' => [
-                'enabled' => true,
-                'sample_rate' => 0 // No events should be sent
-            ]
-        ], null, $eventsDispatcher);
+        $badger = new Honeybadger($config, null, $eventsDispatcher);
 
         // Send an event
         $badger->event('log', ['message' => 'Test message']);
 
         // No events should be in the queue
         $this->assertCount(0, $eventsDispatcher->events);
+    }
+
+    /** @test */
+    public function it_sends_all_events_when_sample_rate_is_one_hundred()
+    {
+        // Create a mock client
+        $client = $this->createMock(\Honeybadger\HoneybadgerClient::class);
+
+        $config = events_config(100);
 
         // Now create a new instance with 100% sampling rate
-        $eventsDispatcher = new class(new Config([
-            'api_key' => '1234',
-            'events' => [
-                'enabled' => true,
-                'sample_rate' => 100 // All events should be sent
-            ]
-        ]), $client) extends BulkEventDispatcher {
+        $eventsDispatcher = new class(new Config($config), $client) extends BulkEventDispatcher {
             public $events = [];
 
             public function addEvent($event): void
@@ -62,13 +55,7 @@ class EventSamplingTest extends TestCase
             }
         };
 
-        $badger = new Honeybadger([
-            'api_key' => '1234',
-            'events' => [
-                'enabled' => true,
-                'sample_rate' => 100 // All events should be sent
-            ]
-        ], null, $eventsDispatcher);
+        $badger = new Honeybadger($config, null, $eventsDispatcher);
 
         // Send an event
         $badger->event('log', ['message' => 'Test message']);
@@ -83,14 +70,10 @@ class EventSamplingTest extends TestCase
         // Create a mock client
         $client = $this->createMock(\Honeybadger\HoneybadgerClient::class);
 
+        $config = events_config(50);
+
         // Create a custom event dispatcher that tracks events
-        $eventsDispatcher = new class(new Config([
-            'api_key' => '1234',
-            'events' => [
-                'enabled' => true,
-                'sample_rate' => 50 // 50% of events should be sent
-            ]
-        ]), $client) extends BulkEventDispatcher {
+        $eventsDispatcher = new class(new Config($config), $client) extends BulkEventDispatcher {
             public $events = [];
 
             public function addEvent($event): void
@@ -100,13 +83,7 @@ class EventSamplingTest extends TestCase
         };
 
         // Create Honeybadger instance with 50% sampling rate
-        $badger = new Honeybadger([
-            'api_key' => '1234',
-            'events' => [
-                'enabled' => true,
-                'sample_rate' => 50 // 50% of events should be sent
-            ]
-        ], null, $eventsDispatcher);
+        $badger = new Honeybadger($config, null, $eventsDispatcher);
 
         // Create a requestId that will be sampled (using a known value that will pass the CRC32 check)
         $sampledRequestId = 'sampled-request-123';
@@ -151,14 +128,10 @@ class EventSamplingTest extends TestCase
         // Create a mock client
         $client = $this->createMock(\Honeybadger\HoneybadgerClient::class);
 
+        $config = events_config(0);
+
         // Create a custom event dispatcher that tracks events
-        $eventsDispatcher = new class(new Config([
-            'api_key' => '1234',
-            'events' => [
-                'enabled' => true,
-                'sample_rate' => 0 // No events should be sent by default
-            ]
-        ]), $client) extends BulkEventDispatcher {
+        $eventsDispatcher = new class(new Config($config), $client) extends BulkEventDispatcher {
             public $events = [];
 
             public function addEvent($event): void
@@ -168,13 +141,7 @@ class EventSamplingTest extends TestCase
         };
 
         // Create Honeybadger instance with 0% sampling rate
-        $badger = new Honeybadger([
-            'api_key' => '1234',
-            'events' => [
-                'enabled' => true,
-                'sample_rate' => 0 // No events should be sent by default
-            ]
-        ], null, $eventsDispatcher);
+        $badger = new Honeybadger($config, null, $eventsDispatcher);
 
         // Send an event with no override - should not be sent
         $badger->event('log', ['message' => 'This event should not be sent']);
@@ -196,14 +163,10 @@ class EventSamplingTest extends TestCase
         // Create a mock client
         $client = $this->createMock(\Honeybadger\HoneybadgerClient::class);
 
+        $config = events_config(100);
+
         // Create a custom event dispatcher that tracks events
-        $eventsDispatcher = new class(new Config([
-            'api_key' => '1234',
-            'events' => [
-                'enabled' => true,
-                'sample_rate' => 100 // All events should be sent
-            ]
-        ]), $client) extends BulkEventDispatcher {
+        $eventsDispatcher = new class(new Config($config), $client) extends BulkEventDispatcher {
             public $events = [];
 
             public function addEvent($event): void
@@ -213,13 +176,7 @@ class EventSamplingTest extends TestCase
         };
 
         // Create Honeybadger instance
-        $badger = new Honeybadger([
-            'api_key' => '1234',
-            'events' => [
-                'enabled' => true,
-                'sample_rate' => 100
-            ]
-        ], null, $eventsDispatcher);
+        $badger = new Honeybadger($config, null, $eventsDispatcher);
 
         // Send an event with _hb metadata
         $badger->event('log', [
@@ -247,14 +204,10 @@ class EventSamplingTest extends TestCase
         // Create a mock client
         $client = $this->createMock(\Honeybadger\HoneybadgerClient::class);
 
+        $config = events_config(0);
+
         // Create a custom event dispatcher that tracks events
-        $eventsDispatcher = new class(new Config([
-            'api_key' => '1234',
-            'events' => [
-                'enabled' => true,
-                'sample_rate' => 0 // No events should be sent by default
-            ]
-        ]), $client) extends BulkEventDispatcher {
+        $eventsDispatcher = new class(new Config($config), $client) extends BulkEventDispatcher {
             public $events = [];
 
             public function addEvent($event): void
@@ -264,13 +217,7 @@ class EventSamplingTest extends TestCase
         };
 
         // Create Honeybadger instance with 0% sampling rate
-        $badger = new Honeybadger([
-            'api_key' => '1234',
-            'events' => [
-                'enabled' => true,
-                'sample_rate' => 0 // No events should be sent by default
-            ]
-        ], null, $eventsDispatcher);
+        $badger = new Honeybadger($config, null, $eventsDispatcher);
 
         // Register a before_event callback that adds the _hb metadata to override sampling
         $badger->beforeEvent(function (&$event) {

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -11,3 +11,14 @@ function array_except($array, $keys)
 {
     return array_diff_key($array, array_flip((array) $keys));
 }
+
+function events_config(int $sample_rate): array
+{
+    return [
+        'api_key' => '1234',
+        'events' => [
+            'enabled' => true,
+            'sample_rate' => $sample_rate
+        ]
+    ];
+}


### PR DESCRIPTION
Give users a configuration option (`events.sample_rate`) to specify what percentage of events will be sent to the API. The configuration option can be overridden with some event metadata (`{_hb: {sample_rate: 100}}`), which allows the user to specify that an event should always be sent, regardless of the default sampling. That metadata will be removed from the event payload before it is sent to the API. 

I tried to stick to the same approach used in the [Ruby implementation](https://github.com/honeybadger-io/honeybadger-ruby/pull/689).