### PR TITLE
perf: increase defaults for events dispatcher

### DIFF
--- a/src/BulkEventDispatcher.php
+++ b/src/BulkEventDispatcher.php
@@ -4,8 +4,8 @@ namespace Honeybadger;
 
 class BulkEventDispatcher
 {
-    const BULK_THRESHOLD = 50;
-    const DISPATCH_INTERVAL_SECONDS = 2;
+    const BULK_THRESHOLD = 200;
+    const DISPATCH_INTERVAL_SECONDS = 30;
 
     /**
      * @var HoneybadgerClient

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -64,8 +64,8 @@ class ConfigTest extends TestCase
             'checkins' => [],
             'events' => [
                 'enabled' => false,
-                'bulk_threshold' => 50,
-                'dispatch_interval_seconds' => 2,
+                'bulk_threshold' => 200,
+                'dispatch_interval_seconds' => 30,
                 'sample_rate' => 100,
             ],
         ], $config);
@@ -130,8 +130,8 @@ class ConfigTest extends TestCase
             'checkins' => [],
             'events' => [
                 'enabled' => false,
-                'bulk_threshold' => 50,
-                'dispatch_interval_seconds' => 2,
+                'bulk_threshold' => 200,
+                'dispatch_interval_seconds' => 30,
                 'sample_rate' => 100,
             ],
         ], $config);


### PR DESCRIPTION
## Status
**READY**

## Description
I realized that I never increased the defaults as per our discussion [here](https://github.com/honeybadger-io/honeybadger-php/issues/203#issuecomment-2491998036).
I'm actually bumping to 200 and setting the interval seconds to 30.
If the queue has events before these thresholds and the request/job/process is complete, the shutdown handler will kick in (and additionally the terminable middleware in the case of Laravel).
