### PR TITLE
fix: omit empty breadcrumbs and tags from custom notifications

### DIFF
--- a/src/CustomNotification.php
+++ b/src/CustomNotification.php
@@ -40,26 +40,36 @@ class CustomNotification
      */
     public function make(array $payload): array
     {
-        return array_merge(
-            [],
-            ['breadcrumbs' => [
+        $notification = [];
+
+        $trail = $this->breadcrumbs->toArray();
+        if (! empty($trail)) {
+            $notification['breadcrumbs'] = [
                 'enabled' => $this->config['breadcrumbs']['enabled'],
-                'trail' => $this->breadcrumbs->toArray(),
-            ]],
-            ['notifier' => $this->config['notifier']],
-            [
-                'error' => [
-                    'class' => $payload['title'] ?? '',
-                    'message' => $payload['message'] ?? '',
-                    'tags' => Arr::wrap($payload['tags'] ?? null),
-                ],
-            ],
-            ['request' => [
-                'context' => (object) $this->context->all(), ],
-            ],
-            ['server' => (object) [
-                'environment_name' => $this->config['environment_name'],
-            ]]
-        );
+                'trail' => $trail,
+            ];
+        }
+
+        $notification['notifier'] = $this->config['notifier'];
+
+        $error = [
+            'class' => $payload['title'] ?? '',
+            'message' => $payload['message'] ?? '',
+        ];
+
+        $tags = Arr::wrap($payload['tags'] ?? null);
+        if (! empty($tags)) {
+            $error['tags'] = $tags;
+        }
+
+        $notification['error'] = $error;
+        $notification['request'] = [
+            'context' => (object) $this->context->all(),
+        ];
+        $notification['server'] = (object) [
+            'environment_name' => $this->config['environment_name'],
+        ];
+
+        return $notification;
     }
 }

--- a/tests/HoneybadgerTest.php
+++ b/tests/HoneybadgerTest.php
@@ -534,6 +534,34 @@ class HoneybadgerTest extends TestCase
     }
 
     /** @test */
+    public function custom_notification_omits_breadcrumbs_when_disabled()
+    {
+        $client = HoneybadgerClient::new([
+            new Response(201),
+        ]);
+
+        $badger = Honeybadger::new([
+            'api_key' => 'asdf',
+            'handlers' => [
+                'exception' => false,
+                'error' => false,
+            ],
+            'breadcrumbs' => ['enabled' => false],
+        ], $client->make());
+
+        $badger->addBreadcrumb('Should Be Ignored', ['key' => 'value'], 'custom');
+
+        $badger->customNotification([
+            'title' => 'Test Title',
+            'message' => 'Test Message',
+        ]);
+
+        $request = $client->requestBody();
+
+        $this->assertArrayNotHasKey('breadcrumbs', $request);
+    }
+
+    /** @test */
     public function custom_notification_omits_tags_when_none_provided()
     {
         $client = HoneybadgerClient::new([

--- a/tests/HoneybadgerTest.php
+++ b/tests/HoneybadgerTest.php
@@ -464,7 +464,6 @@ class HoneybadgerTest extends TestCase
             'error' => [
                 'class' => 'Special Error',
                 'message' => 'Special Error: this was a super special case',
-                'tags' => [],
             ],
             'request' => [
                 'context' => [
@@ -509,7 +508,7 @@ class HoneybadgerTest extends TestCase
     }
 
     /** @test */
-    public function custom_notification_includes_empty_breadcrumbs_when_disabled()
+    public function custom_notification_omits_breadcrumbs_when_none_added()
     {
         $client = HoneybadgerClient::new([
             new Response(201),
@@ -521,7 +520,7 @@ class HoneybadgerTest extends TestCase
                 'exception' => false,
                 'error' => false,
             ],
-            'breadcrumbs' => ['enabled' => false],
+            'breadcrumbs' => ['enabled' => true],
         ], $client->make());
 
         $badger->customNotification([
@@ -531,9 +530,32 @@ class HoneybadgerTest extends TestCase
 
         $request = $client->requestBody();
 
-        $this->assertIsArray($request['breadcrumbs']);
-        $this->assertFalse($request['breadcrumbs']['enabled']);
-        $this->assertCount(0, $request['breadcrumbs']['trail']);
+        $this->assertArrayNotHasKey('breadcrumbs', $request);
+    }
+
+    /** @test */
+    public function custom_notification_omits_tags_when_none_provided()
+    {
+        $client = HoneybadgerClient::new([
+            new Response(201),
+        ]);
+
+        $badger = Honeybadger::new([
+            'api_key' => 'asdf',
+            'handlers' => [
+                'exception' => false,
+                'error' => false,
+            ],
+        ], $client->make());
+
+        $badger->customNotification([
+            'title' => 'Test Title',
+            'message' => 'Test Message',
+        ]);
+
+        $request = $client->requestBody();
+
+        $this->assertArrayNotHasKey('tags', $request['error']);
     }
 
     /** @test */


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes a regression from PR #243 where empty `breadcrumbs` and `tags` keys were always included in custom notification payloads, even when no breadcrumbs were added and no tags were provided. Now these keys are only included when they have actual content.

## Related PRs

branch | PR
------ | ------
master | [#243](https://github.com/honeybadger-io/honeybadger-php/pull/243)

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

```bash
> git pull --prune
> git checkout fix-empty-breadcrumbs-tags
> vendor/bin/phpunit --filter="custom"
```

Verify that:
1. When no breadcrumbs are added, the `breadcrumbs` key is absent from the payload
2. When breadcrumbs are disabled, the `breadcrumbs` key is absent even if `addBreadcrumb()` is called
3. When no tags are provided, the `tags` key is absent from the `error` object
4. When breadcrumbs are added, they appear in the payload
5. When tags are provided, they appear in the `error` object